### PR TITLE
Use discovery mapper first resource result when available

### DIFF
--- a/pkg/k8s/resource.go
+++ b/pkg/k8s/resource.go
@@ -17,9 +17,13 @@ func GetGVRFromResource(discoveryMapper *restmapper.DeferredDiscoveryRESTMapper,
 		gvr = schema.GroupVersionResource{Group: "", Version: s[0], Resource: s[1]}
 	}
 
-	if _, err := discoveryMapper.ResourcesFor(gvr); err != nil {
+	gvrs, err := discoveryMapper.ResourcesFor(gvr)
+	if err != nil {
 		return schema.GroupVersionResource{}, err
 	}
+	if len(gvrs) == 0 {
+		return gvr, nil
+	}
 
-	return gvr, nil
+	return gvrs[0], nil
 }


### PR DESCRIPTION
Allows more flexible definition of the kind in the mapping configuration (accept `singular` and `kind` resource names in addition to `plural`)