### PR TITLE
revert to the old image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           go-version: 1.21
           cache: true
 
+      # https://stackoverflow.com/questions/51475992/cgo-cross-compiling-from-amd64linux-to-arm64linux/75368290#75368290
       - name: musl-cross for CGO Support
         run: |
           mkdir ../../musl-cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist --snapshot
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.21-alpine
 
-USER nonroot:nonroot
-
 ENTRYPOINT ["/usr/bin/port-k8s-exporter"]
 
 COPY port-k8s-exporter /usr/bin/port-k8s-exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.21-alpine
+FROM gcr.io/distroless/static-debian11
+
+USER nonroot:nonroot
 
 ENTRYPOINT ["/usr/bin/port-k8s-exporter"]
 


### PR DESCRIPTION
The docker file is currently failing for 
```
 Error response from daemon: unable to find user nonroot: no matching entries in passwd file
 ```
 because we changed base image and now nonroot user does not exists

reverting to the old image