### PR TITLE
initing the klog.InitFlags from the init() function

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,6 @@ func initiateHandler(exporterConfig *port.Config, k8sClient *k8s.Client, portCli
 }
 
 func main() {
-	klog.InitFlags(nil)
-
 	k8sConfig := k8s.NewKubeConfig()
 	applicationConfig, err := config.NewConfiguration()
 	if err != nil {
@@ -81,5 +79,6 @@ func main() {
 }
 
 func init() {
+	klog.InitFlags(nil)
 	config.Init()
 }


### PR DESCRIPTION
The current version (chart - 0.2.8; app - 0.2.8) of the k8s exporter fails to load with the -v parameter because the `klog.initFlags` function is called in the main function instead of being called from the init function

Fixed the call for this function