### PR TITLE
added OverwriteConfigurationOnRestart configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func Init() {
 	NewString(&ApplicationConfig.PortClientId, "port-client-id", "", "Port client id. Required.")
 	NewString(&ApplicationConfig.PortClientSecret, "port-client-secret", "", "Port client secret. Required.")
 	NewBool(&ApplicationConfig.CreateDefaultResources, "create-default-resources", true, "Create default resources on installation. Optional.")
-	NewBool(&ApplicationConfig.UsePortUIConfig, "use-port-ui-config", true, "Use Port UI configuration after installation instead of the local config file. Optional.")
+	NewBool(&ApplicationConfig.OverwriteConfigurationOnRestart, "overwrite-configuration-on-restart", true, "Overwrite the configuration in port on restarting the exporter. Optional.")
 
 	// Deprecated
 	NewBool(&ApplicationConfig.DeleteDependents, "delete-dependents", false, "Delete dependents. Optional.")
@@ -48,13 +48,13 @@ func Init() {
 
 func NewConfiguration() (*port.Config, error) {
 	overrides := &port.Config{
-		StateKey:                     ApplicationConfig.StateKey,
-		EventListenerType:            ApplicationConfig.EventListenerType,
-		CreateDefaultResources:       ApplicationConfig.CreateDefaultResources,
-		ResyncInterval:               ApplicationConfig.ResyncInterval,
-		UsePortUIConfig:              ApplicationConfig.UsePortUIConfig,
-		CreateMissingRelatedEntities: ApplicationConfig.CreateMissingRelatedEntities,
-		DeleteDependents:             ApplicationConfig.DeleteDependents,
+		StateKey:                        ApplicationConfig.StateKey,
+		EventListenerType:               ApplicationConfig.EventListenerType,
+		CreateDefaultResources:          ApplicationConfig.CreateDefaultResources,
+		ResyncInterval:                  ApplicationConfig.ResyncInterval,
+		OverwriteConfigurationOnRestart: ApplicationConfig.OverwriteConfigurationOnRestart,
+		CreateMissingRelatedEntities:    ApplicationConfig.CreateMissingRelatedEntities,
+		DeleteDependents:                ApplicationConfig.DeleteDependents,
 	}
 
 	v, err := os.ReadFile(ApplicationConfig.ConfigFilePath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,7 @@ func Init() {
 }
 
 func NewConfiguration() (*port.Config, error) {
-	overrides := &port.Config{
+	config := &port.Config{
 		StateKey:                        ApplicationConfig.StateKey,
 		EventListenerType:               ApplicationConfig.EventListenerType,
 		CreateDefaultResources:          ApplicationConfig.CreateDefaultResources,
@@ -61,15 +61,15 @@ func NewConfiguration() (*port.Config, error) {
 	if err != nil {
 		v = []byte("{}")
 		klog.Infof("Config file not found, using defaults")
-		return overrides, nil
+		return config, nil
 	}
 	klog.Infof("Config file found")
-	err = yaml.Unmarshal(v, &overrides)
+	err = yaml.Unmarshal(v, &config)
 	if err != nil {
 		return nil, fmt.Errorf("failed loading configuration: %w", err)
 	}
 
-	overrides.StateKey = strings.ToLower(overrides.StateKey)
+	config.StateKey = strings.ToLower(config.StateKey)
 
-	return overrides, nil
+	return config, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func Init() {
 	NewString(&ApplicationConfig.PortClientId, "port-client-id", "", "Port client id. Required.")
 	NewString(&ApplicationConfig.PortClientSecret, "port-client-secret", "", "Port client secret. Required.")
 	NewBool(&ApplicationConfig.CreateDefaultResources, "create-default-resources", true, "Create default resources on installation. Optional.")
-	NewBool(&ApplicationConfig.OverwriteConfigurationOnRestart, "overwrite-configuration-on-restart", true, "Overwrite the configuration in port on restarting the exporter. Optional.")
+	NewBool(&ApplicationConfig.OverwriteConfigurationOnRestart, "overwrite-configuration-on-restart", false, "Overwrite the configuration in port on restarting the exporter. Optional.")
 
 	// Deprecated
 	NewBool(&ApplicationConfig.DeleteDependents, "delete-dependents", false, "Delete dependents. Optional.")

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -22,10 +22,8 @@ type ApplicationConfiguration struct {
 	EventListenerType               string
 	CreateDefaultResources          bool
 	OverwriteConfigurationOnRestart bool
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	Resources []port.Resource
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	DeleteDependents bool `json:"deleteDependents,omitempty"`
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
+	// These Configurations are used only for setting up the Integration on installation or when using OverwriteConfigurationOnRestart flag.
+	Resources                    []port.Resource
+	DeleteDependents             bool `json:"deleteDependents,omitempty"`
 	CreateMissingRelatedEntities bool `json:"createMissingRelatedEntities,omitempty"`
 }

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -21,6 +21,7 @@ type ApplicationConfiguration struct {
 	PortClientSecret       string
 	EventListenerType      string
 	CreateDefaultResources bool
+	UsePortUIConfig        bool
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
 	Resources []port.Resource
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -13,15 +13,15 @@ type KafkaConfiguration struct {
 }
 
 type ApplicationConfiguration struct {
-	ConfigFilePath         string
-	StateKey               string
-	ResyncInterval         uint
-	PortBaseURL            string
-	PortClientId           string
-	PortClientSecret       string
-	EventListenerType      string
-	CreateDefaultResources bool
-	UsePortUIConfig        bool
+	ConfigFilePath                  string
+	StateKey                        string
+	ResyncInterval                  uint
+	PortBaseURL                     string
+	PortClientId                    string
+	PortClientSecret                string
+	EventListenerType               string
+	CreateDefaultResources          bool
+	OverwriteConfigurationOnRestart bool
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
 	Resources []port.Resource
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -3,10 +3,7 @@ package config
 import (
 	"flag"
 	"github.com/port-labs/port-k8s-exporter/pkg/goutils"
-	"github.com/port-labs/port-k8s-exporter/pkg/port"
-	"gopkg.in/yaml.v2"
 	"k8s.io/utils/strings/slices"
-	"os"
 	"strings"
 )
 
@@ -36,27 +33,4 @@ func NewUInt(v *uint, key string, defaultValue uint, description string) {
 func NewBool(v *bool, key string, defaultValue bool, description string) {
 	value := goutils.GetBoolEnvOrDefault(prepareEnvKey(key), defaultValue)
 	flag.BoolVar(v, key, value, description)
-}
-
-type FileNotFoundError struct {
-	s string
-}
-
-func (e *FileNotFoundError) Error() string {
-	return e.s
-}
-
-func GetConfigFile(filepath string) (*port.Config, error) {
-	c := &port.Config{}
-	config, err := os.ReadFile(filepath)
-	if err != nil {
-		return c, &FileNotFoundError{err.Error()}
-	}
-
-	err = yaml.Unmarshal(config, c)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -192,7 +192,7 @@ func Test_InitIntegration_ExistingIntegration(t *testing.T) {
 	checkResourcesDoesNotExist(f, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"})
 }
 
-func Test_InitIntegration_DeprecatedResourcesConfiguration(t *testing.T) {
+func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
 	f := NewFixture(t)
 	err := integration.CreateIntegration(f.portClient, f.stateKey, "", nil)
 	if err != nil {
@@ -233,7 +233,7 @@ func Test_InitIntegration_DeprecatedResourcesConfiguration(t *testing.T) {
 	checkResourcesDoesNotExist(f, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"})
 }
 
-func Test_InitIntegration_DeprecatedResourcesConfiguration_ExistingIntegration_EmptyConfiguration(t *testing.T) {
+func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_EmptyConfiguration(t *testing.T) {
 	f := NewFixture(t)
 	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", nil)
 	if err != nil {
@@ -250,6 +250,52 @@ func Test_InitIntegration_DeprecatedResourcesConfiguration_ExistingIntegration_E
 	i, err := integration.GetIntegration(f.portClient, f.stateKey)
 	assert.Nil(t, err)
 	assert.Equal(t, "KAFKA", i.EventListener.Type)
+
+	checkResourcesDoesNotExist(f, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"})
+}
+
+func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithConfiguration_WithOverwriteConfigurationOnRestartFlag(t *testing.T) {
+	f := NewFixture(t)
+	expectedResources := &port.IntegrationAppConfig{
+		Resources: []port.Resource{
+			{
+				Kind: "workload",
+				Port: port.Port{
+					Entity: port.EntityMappings{
+						Mappings: []port.EntityMapping{
+							{
+								Identifier: "\"workload\"",
+								Title:      "\"Workload\"",
+								Blueprint:  "\"workload\"",
+								Icon:       "\"Microservice\"",
+								Properties: map[string]string{
+									"namespace": "\"default\"",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", expectedResources)
+	if err != nil {
+		t.Errorf("Error creating Port integration: %s", err.Error())
+	}
+
+	expectedResources.Resources[0].Kind = "namespace"
+	e := InitIntegration(f.portClient, &port.Config{
+		StateKey:                        f.stateKey,
+		EventListenerType:               "KAFKA",
+		Resources:                       expectedResources.Resources,
+		CreateDefaultResources:          true,
+		OverwriteConfigurationOnRestart: true,
+	})
+	assert.Nil(t, e)
+
+	i, err := integration.GetIntegration(f.portClient, f.stateKey)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedResources, i.Config.Resources)
 
 	checkResourcesDoesNotExist(f, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"})
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -256,7 +256,7 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_EmptyC
 
 func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithConfiguration_WithOverwriteConfigurationOnRestartFlag(t *testing.T) {
 	f := NewFixture(t)
-	expectedResources := &port.IntegrationAppConfig{
+	expectedConfig := &port.IntegrationAppConfig{
 		Resources: []port.Resource{
 			{
 				Kind: "workload",
@@ -278,16 +278,16 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 			},
 		},
 	}
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", expectedResources)
+	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", expectedConfig)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}
 
-	expectedResources.Resources[0].Kind = "namespace"
+	expectedConfig.Resources[0].Kind = "namespace"
 	e := InitIntegration(f.portClient, &port.Config{
 		StateKey:                        f.stateKey,
 		EventListenerType:               "KAFKA",
-		Resources:                       expectedResources.Resources,
+		Resources:                       expectedConfig.Resources,
 		CreateDefaultResources:          true,
 		OverwriteConfigurationOnRestart: true,
 	})
@@ -295,7 +295,7 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 
 	i, err := integration.GetIntegration(f.portClient, f.stateKey)
 	assert.Nil(t, err)
-	assert.Equal(t, expectedResources, i.Config.Resources)
+	assert.Equal(t, expectedConfig.Resources, i.Config.Resources)
 
 	checkResourcesDoesNotExist(f, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"})
 }

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -54,7 +54,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 
 		// Handle a deprecated case where resources are provided in config file and integration exists from previous
 		//versions without a config
-		if existingIntegration.Config == nil || !applicationConfig.UsePortUIConfig {
+		if existingIntegration.Config == nil || applicationConfig.OverwriteConfigurationOnRestart {
 			klog.Infof("Integration exists without a config, patching it with default config: %v", defaultIntegrationConfig)
 			integrationPatch.Config = defaultIntegrationConfig
 		}

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -54,7 +54,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 
 		// Handle a deprecated case where resources are provided in config file and integration exists from previous
 		//versions without a config
-		if existingIntegration.Config == nil {
+		if existingIntegration.Config == nil || !applicationConfig.UsePortUIConfig {
 			klog.Infof("Integration exists without a config, patching it with default config: %v", defaultIntegrationConfig)
 			integrationPatch.Config = defaultIntegrationConfig
 		}

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -227,15 +227,13 @@ type IntegrationAppConfig struct {
 }
 
 type Config struct {
-	ResyncInterval                  uint   `yaml:"resyncInterval,omitempty" json:"resyncInterval,omitempty"`
-	StateKey                        string `yaml:"stateKey,omitempty" json:"stateKey,omitempty"`
-	EventListenerType               string `yaml:"eventListenerType,omitempty" json:"eventListenerType,omitempty"`
-	CreateDefaultResources          bool   `yaml:"createDefaultResources,omitempty" json:"createDefaultResources,omitempty"`
-	OverwriteConfigurationOnRestart bool   `yaml:"overwriteConfigurationOnRestart,omitempty" json:"overwriteConfigurationOnRestart,omitempty"`
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	Resources []Resource `yaml:"resources,omitempty" json:"resources,omitempty"`
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	DeleteDependents bool `yaml:"deleteDependents,omitempty" json:"deleteDependents,omitempty"`
-	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	CreateMissingRelatedEntities bool `yaml:"createMissingRelatedEntities,omitempty" json:"createMissingRelatedEntities,omitempty"`
+	ResyncInterval                  uint   `yaml:"resyncInterval,omitempty"`
+	StateKey                        string `yaml:"stateKey,omitempty"`
+	EventListenerType               string `yaml:"eventListenerType,omitempty"`
+	CreateDefaultResources          bool   `yaml:"createDefaultResources,omitempty"`
+	OverwriteConfigurationOnRestart bool   `yaml:"overwriteConfigurationOnRestart,omitempty"`
+	// These Configurations are used only for setting up the Integration on installation or when using OverwriteConfigurationOnRestart flag.
+	Resources                    []Resource `yaml:"resources,omitempty"`
+	DeleteDependents             bool       `yaml:"deleteDependents,omitempty"`
+	CreateMissingRelatedEntities bool       `yaml:"createMissingRelatedEntities,omitempty"`
 }

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -182,7 +182,7 @@ type EntityMapping struct {
 	Identifier string            `json:"identifier"`
 	Title      string            `json:"title"`
 	Blueprint  string            `json:"blueprint"`
-	Icon	   string            `json:"icon,omitempty"`
+	Icon       string            `json:"icon,omitempty"`
 	Team       string            `json:"team,omitempty"`
 	Properties map[string]string `json:"properties,omitempty"`
 	Relations  map[string]string `json:"relations,omitempty"`
@@ -227,14 +227,15 @@ type IntegrationAppConfig struct {
 }
 
 type Config struct {
-	ResyncInterval         uint
-	StateKey               string
-	EventListenerType      string
-	CreateDefaultResources bool
+	ResyncInterval         uint   `yaml:"resyncInterval,omitempty" json:"resyncInterval,omitempty"`
+	StateKey               string `yaml:"stateKey,omitempty" json:"stateKey,omitempty"`
+	EventListenerType      string `yaml:"eventListenerType,omitempty" json:"eventListenerType,omitempty"`
+	CreateDefaultResources bool   `yaml:"createDefaultResources,omitempty" json:"createDefaultResources,omitempty"`
+	UsePortUIConfig        bool   `yaml:"usePortUIConfig,omitempty" json:"usePortUIConfig,omitempty"`
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	Resources []Resource `json:"resources,omitempty"`
+	Resources []Resource `yaml:"resources,omitempty" json:"resources,omitempty"`
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	DeleteDependents bool `json:"deleteDependents,omitempty"`
+	DeleteDependents bool `yaml:"deleteDependents,omitempty" json:"deleteDependents,omitempty"`
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
-	CreateMissingRelatedEntities bool `json:"createMissingRelatedEntities,omitempty"`
+	CreateMissingRelatedEntities bool `yaml:"createMissingRelatedEntities,omitempty" json:"createMissingRelatedEntities,omitempty"`
 }

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -227,11 +227,11 @@ type IntegrationAppConfig struct {
 }
 
 type Config struct {
-	ResyncInterval         uint   `yaml:"resyncInterval,omitempty" json:"resyncInterval,omitempty"`
-	StateKey               string `yaml:"stateKey,omitempty" json:"stateKey,omitempty"`
-	EventListenerType      string `yaml:"eventListenerType,omitempty" json:"eventListenerType,omitempty"`
-	CreateDefaultResources bool   `yaml:"createDefaultResources,omitempty" json:"createDefaultResources,omitempty"`
-	UsePortUIConfig        bool   `yaml:"usePortUIConfig,omitempty" json:"usePortUIConfig,omitempty"`
+	ResyncInterval                  uint   `yaml:"resyncInterval,omitempty" json:"resyncInterval,omitempty"`
+	StateKey                        string `yaml:"stateKey,omitempty" json:"stateKey,omitempty"`
+	EventListenerType               string `yaml:"eventListenerType,omitempty" json:"eventListenerType,omitempty"`
+	CreateDefaultResources          bool   `yaml:"createDefaultResources,omitempty" json:"createDefaultResources,omitempty"`
+	OverwriteConfigurationOnRestart bool   `yaml:"overwriteConfigurationOnRestart,omitempty" json:"overwriteConfigurationOnRestart,omitempty"`
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.
 	Resources []Resource `yaml:"resources,omitempty" json:"resources,omitempty"`
 	// Deprecated: use IntegrationAppConfig instead. Used for updating the Port integration config on startup.


### PR DESCRIPTION
# Description

What - Customers want to control the exporter config from their config map and not from port
Why - IAC
How - Added the OverwriteConfigurationOnRestart flag  to allow the exporter to apply the config to port on each boot

## Type of change

- [X] New feature (non-breaking change which adds functionality)

