### PR TITLE
fixed model to use the yaml parsing

### DIFF
--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -221,9 +221,9 @@ type AggregatedResource struct {
 }
 
 type IntegrationAppConfig struct {
-	DeleteDependents             bool       `json:"deleteDependents,omitempty"`
-	CreateMissingRelatedEntities bool       `json:"createMissingRelatedEntities,omitempty"`
-	Resources                    []Resource `json:"resources,omitempty"`
+	DeleteDependents             bool       `json:"deleteDependents,omitempty" yaml:"deleteDependents,omitempty"`
+	CreateMissingRelatedEntities bool       `json:"createMissingRelatedEntities,omitempty" yaml:"createMissingRelatedEntities,omitempty"`
+	Resources                    []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION
# Description

What - The integration default mapping is ignoring the value for create missing related entities
Why - The parsing key is for json and not yml
How - add parsing for yaml

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

