### PR TITLE
PORT-7636: empty entity title bug fix

### DIFF
--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -20,7 +20,7 @@ type (
 	Entity struct {
 		Meta
 		Identifier string                 `json:"identifier,omitempty"`
-		Title      string                 `json:"title"`
+		Title      string                 `json:"title,omitempty"`
 		Blueprint  string                 `json:"blueprint"`
 		Icon       string                 `json:"icon,omitempty"`
 		Team       interface{}            `json:"team,omitempty"`


### PR DESCRIPTION
# Description

What - Entity `title` had overridden with an empty string
Why - 
How - 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)


