### PR TITLE
Add items to parse functionallity to the mappings

### DIFF
--- a/pkg/jq/parser.go
+++ b/pkg/jq/parser.go
@@ -2,11 +2,12 @@ package jq
 
 import (
 	"fmt"
-	"github.com/itchyny/gojq"
-	"k8s.io/klog/v2"
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/itchyny/gojq"
+	"k8s.io/klog/v2"
 )
 
 var mutex = &sync.Mutex{}
@@ -66,7 +67,7 @@ func ParseString(jqQuery string, obj interface{}) (string, error) {
 
 	str, ok := queryRes.(string)
 	if !ok {
-		return "", fmt.Errorf("failed to parse string: %#v", queryRes)
+		return "", fmt.Errorf("failed to parse string with jq '%#v': %#v", jqQuery, queryRes)
 	}
 
 	return strings.Trim(str, "\""), nil
@@ -79,6 +80,21 @@ func ParseInterface(jqQuery string, obj interface{}) (interface{}, error) {
 	}
 
 	return queryRes, nil
+}
+
+func ParseArray(jqQuery string, obj interface{}) ([]interface{}, error) {
+	queryRes, err := runJQQuery(jqQuery, obj)
+
+	if err != nil {
+		return nil, err
+	}
+
+	items, ok := queryRes.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to parse array with jq '%#v': %#v", jqQuery, queryRes)
+	}
+
+	return items, nil
 }
 
 func ParseMapInterface(jqQueries map[string]string, obj interface{}) (map[string]interface{}, error) {

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/port-labs/port-k8s-exporter/pkg/config"
 	"github.com/port-labs/port-k8s-exporter/pkg/jq"
 	"github.com/port-labs/port-k8s-exporter/pkg/port"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
-	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -184,7 +185,7 @@ func (c *Controller) objectHandler(obj interface{}, item EventItem) error {
 
 	errors := make([]error, 0)
 	for _, kindConfig := range c.resource.KindConfigs {
-		portEntities, err := c.getObjectEntities(obj, kindConfig.Selector, kindConfig.Port.Entity.Mappings)
+		portEntities, err := c.getObjectEntities(obj, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("error getting entities for object key '%s': %v", item.Key, err))
 			continue
@@ -205,7 +206,7 @@ func (c *Controller) objectHandler(obj interface{}, item EventItem) error {
 	return nil
 }
 
-func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping) ([]port.Entity, error) {
+func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping, itemsToParse string) ([]port.Entity, error) {
 	unstructuredObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return nil, fmt.Errorf("error casting to unstructured")
@@ -229,12 +230,28 @@ func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, 
 
 	entities := make([]port.Entity, 0, len(mappings))
 	for _, entityMapping := range mappings {
-		var portEntity *port.Entity
-		portEntity, err = mapping.NewEntity(structuredObj, entityMapping)
-		if err != nil {
-			return nil, fmt.Errorf("invalid entity mapping '%#v': %v", entityMapping, err)
+		if itemsToParse != "" {
+			items, parseItemsError := jq.ParseArray(itemsToParse, structuredObj)
+			if parseItemsError != nil {
+				return nil, parseItemsError
+			} else {
+				for _, item := range items {
+					var portEntity *port.Entity
+					portEntity, err = mapping.NewEntity(item, entityMapping)
+					if err != nil {
+						return nil, fmt.Errorf("invalid entity mapping '%#v': %v", entityMapping, err)
+					}
+					entities = append(entities, *portEntity)
+				}
+			}
+		} else {
+			var portEntity *port.Entity
+			portEntity, err = mapping.NewEntity(structuredObj, entityMapping)
+			if err != nil {
+				return nil, fmt.Errorf("invalid entity mapping '%#v': %v", entityMapping, err)
+			}
+			entities = append(entities, *portEntity)
 		}
-		entities = append(entities, *portEntity)
 	}
 
 	return entities, nil
@@ -323,7 +340,7 @@ func (c *Controller) GetEntitiesSet() (map[string]interface{}, error) {
 					Blueprint:  m.Blueprint,
 				})
 			}
-			entities, err := c.getObjectEntities(obj, kindConfig.Selector, mappings)
+			entities, err := c.getObjectEntities(obj, kindConfig.Selector, mappings, kindConfig.Port.ItemsToParse)
 			if err != nil {
 				return nil, fmt.Errorf("error getting entities of object: %v", err)
 			}

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -248,28 +248,27 @@ func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, 
 		items, parseItemsError := jq.ParseArray(itemsToParse, structuredObj)
 		if parseItemsError != nil {
 			return nil, parseItemsError
-		} else {
-			editedObject, ok := structuredObj.(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("error parsing object '%#v'", structuredObj)
+		}
+		editedObject, ok := structuredObj.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("error parsing object '%#v'", structuredObj)
+		}
+
+		for _, item := range items {
+			editedObject["item"] = item
+			selectorResult, err := isPassSelector(editedObject, selector)
+
+			if err != nil {
+				return nil, err
 			}
 
-			for _, item := range items {
-				editedObject["item"] = item
-				selectorResult, err := isPassSelector(editedObject, selector)
-
+			if selectorResult {
+				currentEntities, err := mapEntities(editedObject, mappings)
 				if err != nil {
 					return nil, err
 				}
 
-				if selectorResult {
-					currentEntities, err := mapEntities(editedObject, mappings)
-					if err != nil {
-						return nil, err
-					}
-
-					entities = append(entities, currentEntities...)
-				}
+				entities = append(entities, currentEntities...)
 			}
 		}
 	} else {

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -3,6 +3,11 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/port-labs/port-k8s-exporter/pkg/config"
 	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
@@ -11,10 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/dynamic/fake"
-	"reflect"
-	"strings"
-	"testing"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -194,7 +194,7 @@ type EntityMappings struct {
 
 type Port struct {
 	Entity       EntityMappings `json:"entity"`
-	ItemsToParse string         `json:"ItemsToParse"`
+	ItemsToParse string         `json:"itemsToParse"`
 }
 
 type Selector struct {

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -179,22 +179,22 @@ type ResponseBody struct {
 }
 
 type EntityMapping struct {
-	Identifier string            `json:"identifier"`
-	Title      string            `json:"title"`
-	Blueprint  string            `json:"blueprint"`
-	Icon       string            `json:"icon,omitempty"`
-	Team       string            `json:"team,omitempty"`
-	Properties map[string]string `json:"properties,omitempty"`
-	Relations  map[string]string `json:"relations,omitempty"`
+	Identifier string            `json:"identifier" yaml:"identifier"`
+	Title      string            `json:"title" yaml:"title"`
+	Blueprint  string            `json:"blueprint" yaml:"blueprint"`
+	Icon       string            `json:"icon,omitempty" yaml:"icon,omitempty"`
+	Team       string            `json:"team,omitempty" yaml:"team,omitempty"`
+	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Relations  map[string]string `json:"relations,omitempty" yaml:"relations,omitempty"`
 }
 
 type EntityMappings struct {
-	Mappings []EntityMapping `json:"mappings"`
+	Mappings []EntityMapping `json:"mappings" yaml:"mappings"`
 }
 
 type Port struct {
-	Entity       EntityMappings `json:"entity"`
-	ItemsToParse string         `json:"itemsToParse"`
+	Entity       EntityMappings `json:"entity" yaml:"entity"`
+	ItemsToParse string         `json:"itemsToParse" yaml:"itemsToParse"`
 }
 
 type Selector struct {
@@ -202,9 +202,9 @@ type Selector struct {
 }
 
 type Resource struct {
-	Kind     string   `json:"kind"`
-	Selector Selector `json:"selector,omitempty"`
-	Port     Port     `json:"port"`
+	Kind     string   `json:"kind" yaml:"kind"`
+	Selector Selector `json:"selector,omitempty" yaml:"selector,omitempty"`
+	Port     Port     `json:"port" yaml:"port"`
 }
 
 type EventListenerSettings struct {

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -193,7 +193,8 @@ type EntityMappings struct {
 }
 
 type Port struct {
-	Entity EntityMappings `json:"entity"`
+	Entity       EntityMappings `json:"entity"`
+	ItemsToParse string         `json:"ItemsToParse"`
 }
 
 type Selector struct {


### PR DESCRIPTION
# Description

What - Add items to parse functionallity to the mappings
Why - To ingest inner entities from base resource

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)

The current mapping:
```yaml
port:
      itemsToParse: .spec.template.spec.containers
      entity:
        mappings:
          - identifier: .item.name + "-Container"
            title: .item.name
            blueprint: '"container"'
            icon: '"Deployment"'
            properties:
              image: .item.image
            relations:
              deployment: .metadata.name + "-Deployment-" + .metadata.namespace

```
Will ingest the containers inside a Kubernetes deployment.
Example deployment yaml with two containers:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "2"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"nginx"},"name":"nginx-deployment","namespace":"default"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"nginx"}},"template":{"metadata":{"labels":{"app":"nginx"}},"spec":{"containers":[{"image":"nginx:1.14.2","name":"nginx","ports":[{"containerPort":80}]}]}}}}
  creationTimestamp: "2024-04-11T14:28:11Z"
  generation: 2
  labels:
    app: nginx
    itamar: hamelech
  name: nginx-deployment
  namespace: default
  resourceVersion: "17669"
  uid: 177fb3eb-fcab-4ae0-b8e9-87fc927d9f03
spec:
  progressDeadlineSeconds: 600
  replicas: 3
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: nginx
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx:1.14.2
        imagePullPolicy: IfNotPresent
        name: nginx
        ports:
        - containerPort: 80
          protocol: TCP
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - image: itamar:1.14.2
        imagePullPolicy: IfNotPresent
        name: itamar
        ports:
        - containerPort: 80
          protocol: TCP
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
status:
  availableReplicas: 3
  conditions:
  - lastTransitionTime: "2024-04-11T14:28:20Z"
    lastUpdateTime: "2024-04-11T14:28:20Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2024-04-11T15:51:32Z"
    lastUpdateTime: "2024-04-11T15:51:32Z"
    message: ReplicaSet "nginx-deployment-5b8b448b96" has timed out progressing.
    reason: ProgressDeadlineExceeded
    status: "False"
    type: Progressing
  observedGeneration: 2
  readyReplicas: 3
  replicas: 4
  unavailableReplicas: 1
  updatedReplicas: 1

```

Will create in Port:
<img width="1256" alt="Screenshot 2024-04-14 at 14 54 48" src="https://github.com/port-labs/port-k8s-exporter/assets/162012674/9103e47f-1cda-4022-9993-b82d52228a84">
