### PR TITLE
fix fatal both in client and in unstructured

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,8 @@ import (
 )
 
 func initiateHandler(exporterConfig *port.Config, k8sClient *k8s.Client) (*handlers.ControllersHandler, error) {
-	portClient, err := cli.New()
-	if err != nil {
-		return nil, fmt.Errorf("error building Port client: %v", err)
-	}
+	portClient := cli.New(config.ApplicationConfig)
+
 	i, err := integration.GetIntegration(portClient, exporterConfig.StateKey)
 	if err != nil {
 		return nil, fmt.Errorf("error getting Port integration: %v", err)
@@ -51,10 +49,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Error building K8s client: %s", err.Error())
 	}
-	portClient, err := cli.New()
-	if err != nil {
-		klog.Fatalf("Error building Port client: %s", err.Error())
-	}
+	portClient := cli.New(config.ApplicationConfig)
 
 	if err := defaults.InitIntegration(portClient, applicationConfig); err != nil {
 		klog.Fatalf("Error initializing Port integration: %s", err.Error())

--- a/main.go
+++ b/main.go
@@ -15,9 +15,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func initiateHandler(exporterConfig *port.Config, k8sClient *k8s.Client) (*handlers.ControllersHandler, error) {
-	portClient := cli.New(config.ApplicationConfig)
-
+func initiateHandler(exporterConfig *port.Config, k8sClient *k8s.Client, portClient *cli.PortClient) (*handlers.ControllersHandler, error) {
 	i, err := integration.GetIntegration(portClient, exporterConfig.StateKey)
 	if err != nil {
 		return nil, fmt.Errorf("error getting Port integration: %v", err)
@@ -55,14 +53,14 @@ func main() {
 		klog.Fatalf("Error initializing Port integration: %s", err.Error())
 	}
 
-	eventListener, err := event_handler.CreateEventListener(applicationConfig.StateKey, applicationConfig.EventListenerType)
+	eventListener, err := event_handler.CreateEventListener(applicationConfig.StateKey, applicationConfig.EventListenerType, portClient)
 	if err != nil {
 		klog.Fatalf("Error creating event listener: %s", err.Error())
 	}
 
 	klog.Info("Starting controllers handler")
 	err = event_handler.Start(eventListener, func() (event_handler.IStoppableRsync, error) {
-		return initiateHandler(applicationConfig, k8sClient)
+		return initiateHandler(applicationConfig, k8sClient, portClient)
 	})
 
 	if err != nil {

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -110,7 +110,7 @@ func newFixture(t *testing.T, portClientId string, portClientSecret string, user
 		userAgent = "port-k8s-exporter/0.1"
 	}
 
-	portClient, err := cli.New(config.ApplicationConfig.PortBaseURL, cli.WithHeader("User-Agent", userAgent),
+	portClient, err := cli.New(cli.WithHeader("User-Agent", userAgent),
 		cli.WithClientID(portClientId), cli.WithClientSecret(portClientSecret))
 	deleteDefaultResources(portClient)
 	if err != nil {

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -26,7 +26,7 @@ func deleteDefaultResources(portClient *cli.PortClient) {
 	_ = blueprint.DeleteBlueprint(portClient, "testkind")
 }
 
-func newFixture(t *testing.T, portClientId string, portClientSecret string, userAgent string, namespaced bool, crdsDiscoveryPattern string) *Fixture {
+func newFixture(t *testing.T, userAgent string, namespaced bool, crdsDiscoveryPattern string) *Fixture {
 	apiExtensionsFakeClient := fakeapiextensionsv1.FakeApiextensionsV1{Fake: &clienttesting.Fake{}}
 
 	apiExtensionsFakeClient.AddReactor("list", "customresourcedefinitions", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -100,22 +100,12 @@ func newFixture(t *testing.T, portClientId string, portClientSecret string, user
 		return true, fakeCrd, nil
 	})
 
-	if portClientId == "" {
-		portClientId = config.ApplicationConfig.PortClientId
-	}
-	if portClientSecret == "" {
-		portClientSecret = config.ApplicationConfig.PortClientSecret
-	}
 	if userAgent == "" {
 		userAgent = "port-k8s-exporter/0.1"
 	}
 
-	portClient, err := cli.New(cli.WithHeader("User-Agent", userAgent),
-		cli.WithClientID(portClientId), cli.WithClientSecret(portClientSecret))
+	portClient := cli.New(config.ApplicationConfig)
 	deleteDefaultResources(portClient)
-	if err != nil {
-		t.Errorf("Error building Port client: %s", err.Error())
-	}
 
 	return &Fixture{
 		t:                  t,
@@ -271,7 +261,7 @@ func checkBlueprintAndActionsProperties(t *testing.T, f *Fixture, namespaced boo
 }
 
 func TestCRD_crd_autoDiscoverCRDsToActionsClusterScoped(t *testing.T) {
-	f := newFixture(t, "", "", "", false, "true")
+	f := newFixture(t, "", false, "true")
 
 	AutodiscoverCRDsToActions(f.portConfig, f.apiextensionClient, f.portClient)
 
@@ -281,7 +271,7 @@ func TestCRD_crd_autoDiscoverCRDsToActionsClusterScoped(t *testing.T) {
 }
 
 func TestCRD_crd_autoDiscoverCRDsToActionsNamespaced(t *testing.T) {
-	f := newFixture(t, "", "", "", true, "true")
+	f := newFixture(t, "", true, "true")
 
 	AutodiscoverCRDsToActions(f.portConfig, f.apiextensionClient, f.portClient)
 
@@ -291,7 +281,7 @@ func TestCRD_crd_autoDiscoverCRDsToActionsNamespaced(t *testing.T) {
 }
 
 func TestCRD_crd_autoDiscoverCRDsToActionsNoCRDs(t *testing.T) {
-	f := newFixture(t, "", "", "", false, "false")
+	f := newFixture(t, "", false, "false")
 
 	AutodiscoverCRDsToActions(f.portConfig, f.apiextensionClient, f.portClient)
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1,7 +1,6 @@
 package defaults
 
 import (
-	"fmt"
 	"testing"
 
 	guuid "github.com/google/uuid"
@@ -23,11 +22,7 @@ type Fixture struct {
 
 func NewFixture(t *testing.T) *Fixture {
 	stateKey := guuid.NewString()
-	portClient, err := cli.New(cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
-		cli.WithClientID(config.ApplicationConfig.PortClientId), cli.WithClientSecret(config.ApplicationConfig.PortClientSecret))
-	if err != nil {
-		t.Errorf("Error building Port client: %s", err.Error())
-	}
+	portClient := cli.New(config.ApplicationConfig)
 
 	deleteDefaultResources(portClient, stateKey)
 	return &Fixture{

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -23,7 +23,7 @@ type Fixture struct {
 
 func NewFixture(t *testing.T) *Fixture {
 	stateKey := guuid.NewString()
-	portClient, err := cli.New(config.ApplicationConfig.PortBaseURL, cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
+	portClient, err := cli.New(cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
 		cli.WithClientID(config.ApplicationConfig.PortClientId), cli.WithClientSecret(config.ApplicationConfig.PortClientSecret))
 	if err != nil {
 		t.Errorf("Error building Port client: %s", err.Error())

--- a/pkg/event_handler/event_listener_factory.go
+++ b/pkg/event_handler/event_listener_factory.go
@@ -3,6 +3,7 @@ package event_handler
 import (
 	"fmt"
 
+	"github.com/port-labs/port-k8s-exporter/pkg/config"
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/consumer"
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/polling"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
@@ -10,10 +11,7 @@ import (
 )
 
 func CreateEventListener(stateKey string, eventListenerType string) (IListener, error) {
-	portClient, err := cli.New()
-	if err != nil {
-		return nil, fmt.Errorf("error building Port client: %v", err)
-	}
+	portClient := cli.New(config.ApplicationConfig)
 
 	klog.Infof("Received event listener type: %s", eventListenerType)
 	switch eventListenerType {

--- a/pkg/event_handler/event_listener_factory.go
+++ b/pkg/event_handler/event_listener_factory.go
@@ -3,16 +3,13 @@ package event_handler
 import (
 	"fmt"
 
-	"github.com/port-labs/port-k8s-exporter/pkg/config"
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/consumer"
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/polling"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
 	"k8s.io/klog/v2"
 )
 
-func CreateEventListener(stateKey string, eventListenerType string) (IListener, error) {
-	portClient := cli.New(config.ApplicationConfig)
-
+func CreateEventListener(stateKey string, eventListenerType string, portClient *cli.PortClient) (IListener, error) {
 	klog.Infof("Received event listener type: %s", eventListenerType)
 	switch eventListenerType {
 	case "KAFKA":

--- a/pkg/event_handler/event_listener_factory.go
+++ b/pkg/event_handler/event_listener_factory.go
@@ -2,13 +2,19 @@ package event_handler
 
 import (
 	"fmt"
+
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/consumer"
 	"github.com/port-labs/port-k8s-exporter/pkg/event_handler/polling"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
 	"k8s.io/klog/v2"
 )
 
-func CreateEventListener(stateKey string, eventListenerType string, portClient *cli.PortClient) (IListener, error) {
+func CreateEventListener(stateKey string, eventListenerType string) (IListener, error) {
+	portClient, err := cli.New()
+	if err != nil {
+		return nil, fmt.Errorf("error building Port client: %v", err)
+	}
+
 	klog.Infof("Received event listener type: %s", eventListenerType)
 	switch eventListenerType {
 	case "KAFKA":

--- a/pkg/event_handler/polling/polling_test.go
+++ b/pkg/event_handler/polling/polling_test.go
@@ -1,8 +1,6 @@
 package polling
 
 import (
-	"fmt"
-
 	_ "github.com/port-labs/port-k8s-exporter/test_utils"
 
 	"testing"
@@ -33,14 +31,10 @@ func (m *MockTicker) GetC() <-chan time.Time {
 
 func NewFixture(t *testing.T, c chan time.Time) *Fixture {
 	stateKey := guuid.NewString()
-	portClient, err := cli.New(cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
-		cli.WithClientID(config.ApplicationConfig.PortClientId), cli.WithClientSecret(config.ApplicationConfig.PortClientSecret))
-	if err != nil {
-		t.Errorf("Error building Port client: %s", err.Error())
-	}
+	portClient := cli.New(config.ApplicationConfig)
 
 	_ = integration.DeleteIntegration(portClient, stateKey)
-	err = integration.CreateIntegration(portClient, stateKey, "", &port.IntegrationAppConfig{
+	err := integration.CreateIntegration(portClient, stateKey, "", &port.IntegrationAppConfig{
 		Resources: []port.Resource{},
 	})
 	if err != nil {

--- a/pkg/event_handler/polling/polling_test.go
+++ b/pkg/event_handler/polling/polling_test.go
@@ -2,7 +2,11 @@ package polling
 
 import (
 	"fmt"
+
 	_ "github.com/port-labs/port-k8s-exporter/test_utils"
+
+	"testing"
+	"time"
 
 	guuid "github.com/google/uuid"
 	"github.com/port-labs/port-k8s-exporter/pkg/config"
@@ -10,8 +14,6 @@ import (
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/integration"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 type Fixture struct {
@@ -31,7 +33,7 @@ func (m *MockTicker) GetC() <-chan time.Time {
 
 func NewFixture(t *testing.T, c chan time.Time) *Fixture {
 	stateKey := guuid.NewString()
-	portClient, err := cli.New(config.ApplicationConfig.PortBaseURL, cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
+	portClient, err := cli.New(cli.WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/0.1 (statekey/%s)", stateKey)),
 		cli.WithClientID(config.ApplicationConfig.PortClientId), cli.WithClientSecret(config.ApplicationConfig.PortClientSecret))
 	if err != nil {
 		t.Errorf("Error building Port client: %s", err.Error())

--- a/pkg/goutils/map.go
+++ b/pkg/goutils/map.go
@@ -22,3 +22,15 @@ func StructToMap(obj interface{}) (newMap map[string]interface{}, err error) {
 	err = json.Unmarshal(data, &newMap)
 	return
 }
+
+func DeepCopy(obj interface{}) interface{} {
+	if obj == nil {
+		return nil
+	}
+
+	var newObj interface{}
+	data, _ := json.Marshal(obj)
+	json.Unmarshal(data, &newObj)
+
+	return newObj
+}

--- a/pkg/goutils/map.go
+++ b/pkg/goutils/map.go
@@ -22,15 +22,3 @@ func StructToMap(obj interface{}) (newMap map[string]interface{}, err error) {
 	err = json.Unmarshal(data, &newMap)
 	return
 }
-
-func DeepCopy(obj interface{}) interface{} {
-	if obj == nil {
-		return nil
-	}
-
-	var newObj interface{}
-	data, _ := json.Marshal(obj)
-	json.Unmarshal(data, &newObj)
-
-	return newObj
-}

--- a/pkg/handlers/controllers.go
+++ b/pkg/handlers/controllers.go
@@ -51,7 +51,7 @@ func NewControllersHandler(exporterConfig *port.Config, portConfig *port.Integra
 		}
 
 		informer := informersFactory.ForResource(gvr)
-		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, portClient, informer, portConfig)
+		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, informer, portConfig)
 		controllers = append(controllers, controller)
 	}
 

--- a/pkg/handlers/controllers.go
+++ b/pkg/handlers/controllers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/port-labs/port-k8s-exporter/pkg/config"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/integration"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/crd"
@@ -52,7 +53,7 @@ func NewControllersHandler(exporterConfig *port.Config, portConfig *port.Integra
 		}
 
 		informer := informersFactory.ForResource(gvr)
-		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, informer, portConfig, nil)
+		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, informer, portConfig, config.ApplicationConfig)
 		controllers = append(controllers, controller)
 	}
 

--- a/pkg/handlers/controllers.go
+++ b/pkg/handlers/controllers.go
@@ -2,8 +2,9 @@ package handlers
 
 import (
 	"context"
-	"github.com/port-labs/port-k8s-exporter/pkg/port/integration"
 	"time"
+
+	"github.com/port-labs/port-k8s-exporter/pkg/port/integration"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/crd"
 	"github.com/port-labs/port-k8s-exporter/pkg/goutils"
@@ -51,7 +52,7 @@ func NewControllersHandler(exporterConfig *port.Config, portConfig *port.Integra
 		}
 
 		informer := informersFactory.ForResource(gvr)
-		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, informer, portConfig)
+		controller := k8s.NewController(port.AggregatedResource{Kind: kind, KindConfigs: kindConfigs}, informer, portConfig, nil)
 		controllers = append(controllers, controller)
 	}
 

--- a/pkg/jq/parser.go
+++ b/pkg/jq/parser.go
@@ -5,14 +5,11 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 
 	"github.com/itchyny/gojq"
 	"github.com/port-labs/port-k8s-exporter/pkg/goutils"
 	"k8s.io/klog/v2"
 )
-
-var mutex = &sync.Mutex{}
 
 func runJQQuery(jqQuery string, obj interface{}) (interface{}, error) {
 	query, err := gojq.Parse(jqQuery)
@@ -30,10 +27,8 @@ func runJQQuery(jqQuery string, obj interface{}) (interface{}, error) {
 		klog.Warningf("failed to compile jq query: %s", jqQuery)
 		return nil, err
 	}
-	mutex.Lock()
 	deepClone := goutils.DeepCopy(obj)
 	queryRes, ok := code.Run(deepClone).Next()
-	mutex.Unlock()
 
 	if !ok {
 		return nil, fmt.Errorf("query should return at least one value")

--- a/pkg/jq/parser.go
+++ b/pkg/jq/parser.go
@@ -30,9 +30,9 @@ func runJQQuery(jqQuery string, obj interface{}) (interface{}, error) {
 		klog.Warningf("failed to compile jq query: %s", jqQuery)
 		return nil, err
 	}
-
 	mutex.Lock()
-	queryRes, ok := code.Run(obj).Next()
+	deepClone := goutils.DeepCopy(obj)
+	queryRes, ok := code.Run(deepClone).Next()
 	mutex.Unlock()
 
 	if !ok {

--- a/pkg/jq/parser.go
+++ b/pkg/jq/parser.go
@@ -27,8 +27,7 @@ func runJQQuery(jqQuery string, obj interface{}) (interface{}, error) {
 		klog.Warningf("failed to compile jq query: %s", jqQuery)
 		return nil, err
 	}
-	deepClone := goutils.DeepCopy(obj)
-	queryRes, ok := code.Run(deepClone).Next()
+	queryRes, ok := code.Run(obj).Next()
 
 	if !ok {
 		return nil, fmt.Errorf("query should return at least one value")

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -51,11 +51,15 @@ type Controller struct {
 	workqueue         workqueue.RateLimitingInterface
 }
 
-func NewController(resource port.AggregatedResource, informer informers.GenericInformer, integrationConfig *port.IntegrationAppConfig) *Controller {
-	portClient, err := cli.New()
-	if err != nil {
-		klog.Fatalf("Error building Port client: %v", err)
+func NewController(resource port.AggregatedResource, informer informers.GenericInformer, integrationConfig *port.IntegrationAppConfig, portClient *cli.PortClient) *Controller {
+	if portClient == nil {
+		var err error
+		portClient, err = cli.New()
+		if err != nil {
+			klog.Fatalf("Error building Port client: %v", err)
+		}
 	}
+
 	cli.WithDeleteDependents(integrationConfig.DeleteDependents)(portClient)
 	cli.WithCreateMissingRelatedEntities(integrationConfig.CreateMissingRelatedEntities)(portClient)
 	controller := &Controller{

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -52,6 +52,7 @@ type Controller struct {
 }
 
 func NewController(resource port.AggregatedResource, informer informers.GenericInformer, integrationConfig *port.IntegrationAppConfig, applicationConfig *config.ApplicationConfiguration) *Controller {
+	// We create a new Port client for each controller because the Resty client is not thread-safe.
 	portClient := cli.New(applicationConfig)
 
 	cli.WithDeleteDependents(integrationConfig.DeleteDependents)(portClient)

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -51,14 +51,8 @@ type Controller struct {
 	workqueue         workqueue.RateLimitingInterface
 }
 
-func NewController(resource port.AggregatedResource, informer informers.GenericInformer, integrationConfig *port.IntegrationAppConfig, portClient *cli.PortClient) *Controller {
-	if portClient == nil {
-		var err error
-		portClient, err = cli.New()
-		if err != nil {
-			klog.Fatalf("Error building Port client: %v", err)
-		}
-	}
+func NewController(resource port.AggregatedResource, informer informers.GenericInformer, integrationConfig *port.IntegrationAppConfig, applicationConfig *config.ApplicationConfiguration) *Controller {
+	portClient := cli.New(applicationConfig)
 
 	cli.WithDeleteDependents(integrationConfig.DeleteDependents)(portClient)
 	cli.WithCreateMissingRelatedEntities(integrationConfig.CreateMissingRelatedEntities)(portClient)

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -253,7 +253,7 @@ func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, 
 		return nil, nil, fmt.Errorf("error casting to unstructured")
 	}
 	var structuredObj interface{}
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &structuredObj)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.DeepCopy().Object, &structuredObj)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error converting from unstructured: %v", err)
 	}

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -59,23 +59,19 @@ func newFixture(t *testing.T, fixtureConfig *fixtureConfig) *fixture {
 	}
 	kubeclient := k8sfake.NewSimpleDynamicClient(runtime.NewScheme())
 
-	if fixtureConfig.portClientId == "" {
-		fixtureConfig.portClientId = config.ApplicationConfig.PortClientId
+	if fixtureConfig.portClientId != "" {
+		config.ApplicationConfig.PortClientId = fixtureConfig.portClientId
 	}
-	if fixtureConfig.portClientSecret == "" {
-		fixtureConfig.portClientSecret = config.ApplicationConfig.PortClientSecret
+	if fixtureConfig.portClientSecret != "" {
+		config.ApplicationConfig.PortClientSecret = fixtureConfig.portClientSecret
 	}
-	if fixtureConfig.stateKey == "" {
-		fixtureConfig.stateKey = "port-k8s-exporter/0.1"
+	if fixtureConfig.stateKey != "" {
+		config.ApplicationConfig.StateKey = fixtureConfig.stateKey
 	}
 
 	return &fixture{
-		t: t,
-		controller: newController(fixtureConfig.resource, fixtureConfig.objects, kubeclient, interationConfig, &config.ApplicationConfiguration{
-			StateKey:         fixtureConfig.stateKey,
-			PortClientId:     fixtureConfig.portClientId,
-			PortClientSecret: fixtureConfig.portClientSecret,
-		}),
+		t:          t,
+		controller: newController(fixtureConfig.resource, fixtureConfig.objects, kubeclient, interationConfig, config.ApplicationConfig),
 	}
 }
 

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -59,19 +59,35 @@ func newFixture(t *testing.T, fixtureConfig *fixtureConfig) *fixture {
 	}
 	kubeclient := k8sfake.NewSimpleDynamicClient(runtime.NewScheme())
 
+	newConfig := &config.ApplicationConfiguration{
+		ConfigFilePath:                  config.ApplicationConfig.ConfigFilePath,
+		ResyncInterval:                  config.ApplicationConfig.ResyncInterval,
+		PortBaseURL:                     config.ApplicationConfig.PortBaseURL,
+		EventListenerType:               config.ApplicationConfig.EventListenerType,
+		CreateDefaultResources:          config.ApplicationConfig.CreateDefaultResources,
+		OverwriteConfigurationOnRestart: config.ApplicationConfig.OverwriteConfigurationOnRestart,
+		Resources:                       config.ApplicationConfig.Resources,
+		DeleteDependents:                config.ApplicationConfig.DeleteDependents,
+		CreateMissingRelatedEntities:    config.ApplicationConfig.CreateMissingRelatedEntities,
+		UpdateEntityOnlyOnDiff:          config.ApplicationConfig.UpdateEntityOnlyOnDiff,
+		PortClientId:                    config.ApplicationConfig.PortClientId,
+		PortClientSecret:                config.ApplicationConfig.PortClientSecret,
+		StateKey:                        config.ApplicationConfig.StateKey,
+	}
+
 	if fixtureConfig.portClientId != "" {
-		config.ApplicationConfig.PortClientId = fixtureConfig.portClientId
+		newConfig.PortClientId = fixtureConfig.portClientId
 	}
 	if fixtureConfig.portClientSecret != "" {
-		config.ApplicationConfig.PortClientSecret = fixtureConfig.portClientSecret
+		newConfig.PortClientSecret = fixtureConfig.portClientSecret
 	}
 	if fixtureConfig.stateKey != "" {
-		config.ApplicationConfig.StateKey = fixtureConfig.stateKey
+		newConfig.StateKey = fixtureConfig.stateKey
 	}
 
 	return &fixture{
 		t:          t,
-		controller: newController(fixtureConfig.resource, fixtureConfig.objects, kubeclient, interationConfig, config.ApplicationConfig),
+		controller: newController(fixtureConfig.resource, fixtureConfig.objects, kubeclient, interationConfig, newConfig),
 	}
 }
 

--- a/pkg/port/cli/client.go
+++ b/pkg/port/cli/client.go
@@ -22,16 +22,10 @@ type (
 	}
 )
 
-func New(opts ...Option) (*PortClient, error) {
-	applicationConfig, err := config.NewConfiguration()
-
-	if err != nil {
-		return nil, err
-	}
-
+func New(applicationConfig *config.ApplicationConfiguration, opts ...Option) *PortClient {
 	c := &PortClient{
 		Client: resty.New().
-			SetBaseURL(config.ApplicationConfig.PortBaseURL).
+			SetBaseURL(applicationConfig.PortBaseURL).
 			SetRetryCount(5).
 			SetRetryWaitTime(300).
 			// retry when create permission fails because scopes are created async-ly and sometimes (mainly in tests) the scope doesn't exist yet.
@@ -48,15 +42,15 @@ func New(opts ...Option) (*PortClient, error) {
 			}),
 	}
 
-	WithClientID(config.ApplicationConfig.PortClientId)(c)
-	WithClientSecret(config.ApplicationConfig.PortClientSecret)(c)
+	WithClientID(applicationConfig.PortClientId)(c)
+	WithClientSecret(applicationConfig.PortClientSecret)(c)
 	WithHeader("User-Agent", fmt.Sprintf("port-k8s-exporter/^0.3.4 (statekey/%s)", applicationConfig.StateKey))(c)
 
 	for _, opt := range opts {
 		opt(c)
 	}
 
-	return c, nil
+	return c
 }
 
 func (c *PortClient) Authenticate(ctx context.Context, clientID, clientSecret string) (string, error) {


### PR DESCRIPTION
# Description

What - There was a fatal concurrent map write/read in a cahce of the informer racing with the JQ parser that uses the same object, and also while taking a look at this issue using the `go run --race` flag I found another race condition that is fixed via this PR.
Why - Bug
How - 
* Port client - Added a port client per controller rather having one globall
* Concurrent map write in entities - Deep copying the structures, less perfroment but as we don't have access to the actual object this solution will be good for now.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Adding a before + after screenshots using the `--race` flag

## Before
### JQ race
![image](https://github.com/port-labs/port-k8s-exporter/assets/51213812/86eeefca-4f3b-4838-96a8-b9c22ac48922)
### Client race
![image](https://github.com/port-labs/port-k8s-exporter/assets/51213812/46a1ef3b-efe0-4d33-9b98-2698626af88e)

## After
![image](https://github.com/port-labs/port-k8s-exporter/assets/51213812/e0e9f0dc-15c8-4b06-b35e-4dafc0ec0643)

