### PR TITLE
bump to go 1.22.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
           cache: true
 
       # https://stackoverflow.com/questions/51475992/cgo-cross-compiling-from-amd64linux-to-arm64linux/75368290#75368290

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/port-labs/port-k8s-exporter
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.7
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.2.0
@@ -12,7 +10,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.0
 	k8s.io/apiextensions-apiserver v0.30.0
@@ -56,6 +53,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect


### PR DESCRIPTION
# Description

What - Bump golang version to 1.22.7
Why - Resolve vulnerabilities 
```
docker scout cves ghcr.io/port-labs/port-k8s-exporter:0.4.1
    i New version 1.13.0 available (installed version is 1.2.0) at https://github.com/docker/scout-cli
    ✓ SBOM of image already cached, 66 packages indexed
    ✗ Detected 2 vulnerable packages with a total of 8 vulnerabilities


## Overview

                    │               Analyzed Image
────────────────────┼──────────────────────────────────────────────
  Target            │  ghcr.io/port-labs/port-k8s-exporter:0.4.1
    digest          │  53d1a8e938bf
    platform        │ linux/arm64
    vulnerabilities │    1C     4H     2M     0L     1?
    size            │ 30 MB
    packages        │ 66


## Packages and Vulnerabilities

   1C     4H     1M     0L     1?  stdlib 1.22.3
pkg:golang/stdlib@1.22.3

    ✗ CRITICAL CVE-2024-24790
      https://scout.docker.com/v/CVE-2024-24790?s=golang&n=stdlib&t=golang&vr=%3E%3D1.22.0-0%2C%3C1.22.4
      Affected range : >=1.22.0-0
                     : <1.22.4
      Fixed version  : 1.22.4

    ✗ HIGH CVE-2024-34158
      https://scout.docker.com/v/CVE-2024-34158?s=golang&n=stdlib&t=golang&vr=%3C1.22.7
      Affected range : <1.22.7
      Fixed version  : 1.22.7

    ✗ HIGH CVE-2024-34156
      https://scout.docker.com/v/CVE-2024-34156?s=golang&n=stdlib&t=golang&vr=%3C1.22.7
      Affected range : <1.22.7
      Fixed version  : 1.22.7

    ✗ HIGH CVE-2024-24791
      https://scout.docker.com/v/CVE-2024-24791?s=golang&n=stdlib&t=golang&vr=%3E%3D1.22.0-0%2C%3C1.22.5
      Affected range : >=1.22.0-0
                     : <1.22.5
      Fixed version  : 1.22.5

    ✗ HIGH CVE-2022-30635
      https://scout.docker.com/v/CVE-2022-30635?s=golang&n=stdlib&t=golang&vr=%3C1.22.7
      Affected range : <1.22.7
      Fixed version  : 1.22.7

    ✗ MEDIUM CVE-2024-24789
      https://scout.docker.com/v/CVE-2024-24789?s=golang&n=stdlib&t=golang&vr=%3E%3D1.22.0-0%2C%3C1.22.4
      Affected range : >=1.22.0-0
                     : <1.22.4
      Fixed version  : 1.22.4

    ✗ UNSPECIFIED CVE-2024-34155
      https://scout.docker.com/v/CVE-2024-34155?s=golang&n=stdlib&t=golang&vr=%3C1.22.7
      Affected range : <1.22.7
      Fixed version  : 1.22.7


   0C     0H     1M     0L  github.com/go-resty/resty/v2 2.7.0
pkg:golang/github.com/go-resty/resty/v2@2.7.0

    ✗ MEDIUM CVE-2023-45286 [OWASP Top Ten 2017 Category A9 - Using Components with Known Vulnerabilities]
      https://scout.docker.com/v/CVE-2023-45286?s=gitlab&n=v2&ns=github.com%2Fgo-resty%2Fresty&t=golang&vr=%3C%3Dv2.10.0
      Affected range : <=v2.10.0
      Fixed version  : not fixed
      CVSS Score     : 5.9
      CVSS Vector    : CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N



8 vulnerabilities found in 2 packages
  UNSPECIFIED  1
  LOW          0
  MEDIUM       2
  HIGH         4
  CRITICAL     1

```
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

