### PR TITLE
fix(template): rename hasLimit rule identifier

### DIFF
--- a/assets/defaults/scorecards.json
+++ b/assets/defaults/scorecards.json
@@ -22,7 +22,7 @@
             }
           },
           {
-            "identifier": "hasLimits",
+            "identifier": "hasLimitsRule",
             "title": "All containers have CPU and Memory limits",
             "level": "Bronze",
             "query": {


### PR DESCRIPTION
# Description

`hasLimit` rule identifier has the same identifier as the property, this is invalid and should be fixed

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

