### PR TITLE
Added missing crdsToDiscover and overwriteCrdsActions config options to initIntegration config mapping

### DIFF
--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -21,6 +21,8 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 	existingIntegration, err := integration.GetIntegration(portClient, applicationConfig.StateKey)
 	defaultIntegrationConfig := &port.IntegrationAppConfig{
 		Resources:                    applicationConfig.Resources,
+		CRDSToDiscover:               applicationConfig.CRDSToDiscover,
+		OverwriteCRDsActions:         applicationConfig.OverwriteCRDsActions,
 		DeleteDependents:             applicationConfig.DeleteDependents,
 		CreateMissingRelatedEntities: applicationConfig.CreateMissingRelatedEntities,
 	}


### PR DESCRIPTION
# Description

What - Added missing crdsToDiscover and overwriteCrdsActions config options to initIntegration config mapping
Why - usage of those options wasn't possible through configmap

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

