### PR TITLE
Enable multiple installations by not failing if all existing default resources exists

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -204,9 +204,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	}
 	waitGroup.Wait()
 
-	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-	}
-
 	for _, patchStage := range patchStages {
 		for _, bp := range patchStage {
 			waitGroup.Add(1)
@@ -219,9 +216,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 			}(bp)
 		}
 		waitGroup.Wait()
-	}
-
-	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
 	}
 
 	for _, blueprintScorecards := range defaults.Scorecards {
@@ -238,9 +232,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	}
 	waitGroup.Wait()
 
-	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-	}
-
 	for _, pageToCreate := range defaults.Pages {
 		waitGroup.Add(1)
 		go func(p port.Page) {
@@ -256,11 +247,11 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	}
 	waitGroup.Wait()
 
-	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-	}
+	validateResourcesErrors(createdBlueprints, createdPages, resourceErrors)
 
 	if err := integration.CreateIntegration(portClient, config.StateKey, config.EventListenerType, defaults.AppConfig); err != nil {
 		klog.Warningf("Failed to create integration with default configuration. state key %s: %v", config.StateKey, err.Error())
+		return &AbortDefaultCreationError{BlueprintsToRollback: createdBlueprints, PagesToRollback: createdPages, Errors: []error{err}}
 	}
 
 	return nil

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -174,7 +174,6 @@ func validateResourcesDoesNotExist(portClient *cli.PortClient, defaults *Default
 func createResources(portClient *cli.PortClient, defaults *Defaults, config *port.Config) *AbortDefaultCreationError {
 	if err := validateResourcesDoesNotExist(portClient, defaults, config); err != nil {
 		klog.Warningf("Failed to create resources: %v.", err.Errors)
-		return err
 	}
 
 	bareBlueprints, patchStages := deconstructBlueprintsToCreationSteps(defaults.Blueprints)
@@ -206,7 +205,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	waitGroup.Wait()
 
 	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-		return err
 	}
 
 	for _, patchStage := range patchStages {
@@ -224,7 +222,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	}
 
 	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-		return err
 	}
 
 	for _, blueprintScorecards := range defaults.Scorecards {
@@ -242,7 +239,6 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	waitGroup.Wait()
 
 	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-		return err
 	}
 
 	for _, pageToCreate := range defaults.Pages {
@@ -261,12 +257,10 @@ func createResources(portClient *cli.PortClient, defaults *Defaults, config *por
 	waitGroup.Wait()
 
 	if err := validateResourcesErrors(createdBlueprints, createdPages, resourceErrors); err != nil {
-		return err
 	}
 
 	if err := integration.CreateIntegration(portClient, config.StateKey, config.EventListenerType, defaults.AppConfig); err != nil {
 		klog.Warningf("Failed to create integration with default configuration. state key %s: %v", config.StateKey, err.Error())
-		return &AbortDefaultCreationError{BlueprintsToRollback: createdBlueprints, PagesToRollback: createdPages, Errors: []error{err}}
 	}
 
 	return nil

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -137,7 +137,7 @@ func Test_InitIntegration_BlueprintExists(t *testing.T) {
 	_, err = blueprint.GetBlueprint(f.portClient, "workload")
 	assert.Nil(t, err)
 
-	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_PageExists(t *testing.T) {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -131,13 +131,13 @@ func Test_InitIntegration_BlueprintExists(t *testing.T) {
 	assert.Nil(t, e)
 
 	i, err := integration.GetIntegration(f.portClient, f.stateKey)
-	assert.Nil(t, i.Config.Resources)
+	assert.NotNil(t, i.Config.Resources)
 	assert.Nil(t, err)
 
 	_, err = blueprint.GetBlueprint(f.portClient, "workload")
 	assert.Nil(t, err)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_PageExists(t *testing.T) {
@@ -157,13 +157,13 @@ func Test_InitIntegration_PageExists(t *testing.T) {
 	assert.Nil(t, e)
 
 	i, err := integration.GetIntegration(f.portClient, f.stateKey)
-	assert.Nil(t, i.Config.Resources)
+	assert.NotNil(t, i.Config.Resources)
 	assert.Nil(t, err)
 
 	_, err = page.GetPage(f.portClient, "workload_overview_dashboard")
 	assert.Nil(t, err)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_ExistingIntegration(t *testing.T) {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -183,7 +183,7 @@ func Test_InitIntegration_ExistingIntegration(t *testing.T) {
 	_, err = integration.GetIntegration(f.portClient, f.stateKey)
 	assert.Nil(t, err)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
@@ -225,7 +225,7 @@ func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
 	assert.Equal(t, expectedResources, i.Config.Resources)
 	assert.Nil(t, err)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_EmptyConfiguration(t *testing.T) {
@@ -247,11 +247,12 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_EmptyC
 	assert.Nil(t, err)
 	assert.Equal(t, "KAFKA", i.EventListener.Type)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
 
 func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithConfiguration_WithOverwriteConfigurationOnRestartFlag(t *testing.T) {
 	f := NewFixture(t)
+	defer tearDownFixture(t, f)
 
 	expectedConfig := &port.IntegrationAppConfig{
 		Resources: []port.Resource{
@@ -294,7 +295,5 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 	assert.Nil(t, err)
 	assert.Equal(t, expectedConfig.Resources, i.Config.Resources)
 
-	testUtils.CheckResourcesExistence(false, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
-	defer tearDownFixture(t, f)
-
+	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -37,7 +37,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 			defaultIntegrationConfig = defaults.AppConfig
 		}
 
-		klog.Infof("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
+		klog.warningf("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
 		if err := integration.CreateIntegration(portClient, applicationConfig.StateKey, applicationConfig.EventListenerType, defaultIntegrationConfig); err != nil {
 			return err
 		}

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -37,7 +37,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 			defaultIntegrationConfig = defaults.AppConfig
 		}
 
-		klog.warningf("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
+		klog.Warningf("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
 		if err := integration.CreateIntegration(portClient, applicationConfig.StateKey, applicationConfig.EventListenerType, defaultIntegrationConfig); err != nil {
 			return err
 		}

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -29,38 +29,31 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 
 	if err != nil {
 		klog.Infof("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
-		klog.Infof("Creating integration")
-		// The exporter supports a deprecated case where resources are provided in config file and integration does not
-		// exist. If this is not the case, we support the new way of creating the integration with the default resources.
-		// Only one of the two cases can be true.
-		if defaultIntegrationConfig.Resources == nil && applicationConfig.CreateDefaultResources {
-			klog.Infof("Creating default resources")
-			if err := initializeDefaults(portClient, applicationConfig); err != nil {
-				klog.Warningf("Error initializing defaults: %s", err.Error())
-				klog.Warningf("The integration will start without default integration mapping and other default resources. Please create them manually in Port. ")
-			} else {
-				klog.Infof("Default resources created successfully")
-				return nil
-			}
+		if err := integration.CreateIntegration(portClient, applicationConfig.StateKey, applicationConfig.EventListenerType, defaultIntegrationConfig); err != nil {
+			return err
 		}
-
-		klog.Infof("Could not create default resources, creating integration with no resources")
-		klog.Infof("Creating integration with config: %v", defaultIntegrationConfig)
-		// Handle a deprecated case where resources are provided in config file
-		return integration.CreateIntegration(portClient, applicationConfig.StateKey, applicationConfig.EventListenerType, defaultIntegrationConfig)
 	} else {
 		klog.Infof("Integration with state key %s already exists, patching it", applicationConfig.StateKey)
 		integrationPatch := &port.Integration{
 			EventListener: getEventListenerConfig(applicationConfig.EventListenerType),
 		}
 
-		// Handle a deprecated case where resources are provided in config file and integration exists from previous
-		//versions without a config
 		if existingIntegration.Config == nil || applicationConfig.OverwriteConfigurationOnRestart {
-			klog.Infof("Integration exists without a config, patching it with default config: %v", defaultIntegrationConfig)
 			integrationPatch.Config = defaultIntegrationConfig
 		}
 
-		return integration.PatchIntegration(portClient, applicationConfig.StateKey, integrationPatch)
+		if err := integration.PatchIntegration(portClient, applicationConfig.StateKey, integrationPatch); err != nil {
+			return err
+		}
 	}
+
+	if applicationConfig.CreateDefaultResources {
+		klog.Infof("Creating default resources")
+		if err := initializeDefaults(portClient); err != nil {
+			klog.Warningf("Error initializing defaults: %s", err.Error())
+			klog.Warningf("Some default resources may not have been created. The integration will continue running.")
+		}
+	}
+
+	return nil
 }

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -57,7 +57,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 	}
 
 	if applicationConfig.CreateDefaultResources {
-		klog.Infof("Creating default resources")
+		klog.Infof("Creating default resources (blueprints, pages, etc..)")
 		if err := initializeDefaults(portClient, defaults); err != nil {
 			klog.Warningf("Error initializing defaults: %s", err.Error())
 			klog.Warningf("Some default resources may not have been created. The integration will continue running.")


### PR DESCRIPTION
# Description

Align logic of default resource creation with ocean, AKA if any of the blueprints already exist, skip the creation of the rest without failing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
