### PR TITLE
Port 12682 support new provisioning on k8s-exporter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ func Init() {
 	NewString(&ApplicationConfig.PortClientId, "port-client-id", "", "Port client id. Required.")
 	NewString(&ApplicationConfig.PortClientSecret, "port-client-secret", "", "Port client secret. Required.")
 	NewBool(&ApplicationConfig.CreateDefaultResources, "create-default-resources", true, "Create default resources on installation. Optional.")
-	NewCreatePortResourcesOrigin(&ApplicationConfig.CreatePortResourcesOrigin, "create-default-resources-origin", "Port", "Create default resources on installation. Optional.")
+	NewCreatePortResourcesOrigin(&ApplicationConfig.CreatePortResourcesOrigin, "create-default-resources-origin", "Port", "Create default resources origin on installation. Optional.")
 
 	NewBool(&ApplicationConfig.OverwriteConfigurationOnRestart, "overwrite-configuration-on-restart", false, "Overwrite the configuration in port on restarting the exporter. Optional.")
 
@@ -54,7 +54,7 @@ func NewConfiguration() (*port.Config, error) {
 		StateKey:                        ApplicationConfig.StateKey,
 		EventListenerType:               ApplicationConfig.EventListenerType,
 		CreateDefaultResources:          ApplicationConfig.CreateDefaultResources,
-		CreatePortResourcesOrigin:       port.CreatePortResourcesOrigin(ApplicationConfig.CreatePortResourcesOrigin),
+		CreatePortResourcesOrigin:       ApplicationConfig.CreatePortResourcesOrigin,
 		ResyncInterval:                  ApplicationConfig.ResyncInterval,
 		OverwriteConfigurationOnRestart: ApplicationConfig.OverwriteConfigurationOnRestart,
 		CreateMissingRelatedEntities:    ApplicationConfig.CreateMissingRelatedEntities,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,8 @@ func Init() {
 	NewString(&ApplicationConfig.PortClientId, "port-client-id", "", "Port client id. Required.")
 	NewString(&ApplicationConfig.PortClientSecret, "port-client-secret", "", "Port client secret. Required.")
 	NewBool(&ApplicationConfig.CreateDefaultResources, "create-default-resources", true, "Create default resources on installation. Optional.")
+	NewCreatePortResourcesOrigin(&ApplicationConfig.CreatePortResourcesOrigin, "create-default-resources-origin", "Port", "Create default resources on installation. Optional.")
+
 	NewBool(&ApplicationConfig.OverwriteConfigurationOnRestart, "overwrite-configuration-on-restart", false, "Overwrite the configuration in port on restarting the exporter. Optional.")
 
 	// Deprecated
@@ -52,6 +54,7 @@ func NewConfiguration() (*port.Config, error) {
 		StateKey:                        ApplicationConfig.StateKey,
 		EventListenerType:               ApplicationConfig.EventListenerType,
 		CreateDefaultResources:          ApplicationConfig.CreateDefaultResources,
+		CreatePortResourcesOrigin:       port.CreatePortResourcesOrigin(ApplicationConfig.CreatePortResourcesOrigin),
 		ResyncInterval:                  ApplicationConfig.ResyncInterval,
 		OverwriteConfigurationOnRestart: ApplicationConfig.OverwriteConfigurationOnRestart,
 		CreateMissingRelatedEntities:    ApplicationConfig.CreateMissingRelatedEntities,

--- a/pkg/config/models.go
+++ b/pkg/config/models.go
@@ -21,6 +21,7 @@ type ApplicationConfiguration struct {
 	PortClientSecret                string
 	EventListenerType               string
 	CreateDefaultResources          bool
+	CreatePortResourcesOrigin       port.CreatePortResourcesOrigin
 	OverwriteConfigurationOnRestart bool
 	// These Configurations are used only for setting up the Integration on installation or when using OverwriteConfigurationOnRestart flag.
 	Resources                    []port.Resource

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -42,7 +42,6 @@ func NewCreatePortResourcesOrigin(target *port.CreatePortResourcesOrigin, key, d
 	var value string
 	flag.StringVar(&value, key, defaultValue, description)
 
-	// Validate and assign to the target after parsing
 	*target = port.CreatePortResourcesOrigin(value)
 	if *target != port.CreatePortResourcesOriginPort && *target != port.CreatePortResourcesOriginK8S {
 		panic(fmt.Sprintf("Invalid value for %s: %s. Must be one of [Port, K8S]", key, value))

--- a/pkg/config/utils.go
+++ b/pkg/config/utils.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"flag"
+	"fmt"
+	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"strings"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/goutils"
@@ -34,4 +36,15 @@ func NewUInt(v *uint, key string, defaultValue uint, description string) {
 func NewBool(v *bool, key string, defaultValue bool, description string) {
 	value := goutils.GetBoolEnvOrDefault(prepareEnvKey(key), defaultValue)
 	flag.BoolVar(v, key, value, description)
+}
+
+func NewCreatePortResourcesOrigin(target *port.CreatePortResourcesOrigin, key, defaultValue, description string) {
+	var value string
+	flag.StringVar(&value, key, defaultValue, description)
+
+	// Validate and assign to the target after parsing
+	*target = port.CreatePortResourcesOrigin(value)
+	if *target != port.CreatePortResourcesOriginPort && *target != port.CreatePortResourcesOriginK8S {
+		panic(fmt.Sprintf("Invalid value for %s: %s. Must be one of [Port, K8S]", key, value))
+	}
 }

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -305,20 +305,3 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 
 	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
 }
-
-func Test_InitIntegration_With_CreatePortResourcesOriginPort_FeatureFlag(t *testing.T) {
-	f := NewFixture(t)
-	defer tearDownFixture(t, f)
-
-	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:                  f.stateKey,
-		EventListenerType:         "POLLING",
-		CreateDefaultResources:    true,
-		CreatePortResourcesOrigin: port.CreatePortResourcesOriginPort,
-	})
-	assert.Nil(t, e)
-
-	i, err := integration.GetIntegration(f.portClient, f.stateKey)
-	assert.Nil(t, err)
-	assert.NotNil(t, i)
-}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -41,9 +41,9 @@ func NewFixture(t *testing.T) *Fixture {
 }
 
 func (f *Fixture) CreateIntegration() {
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "", &port.IntegrationAppConfig{
+	_, err := integration.CreateIntegration(f.portClient, f.stateKey, "", &port.IntegrationAppConfig{
 		Resources: []port.Resource{},
-	})
+	}, false)
 
 	if err != nil {
 		f.t.Errorf("Error creating Port integration: %s", err.Error())
@@ -70,9 +70,10 @@ func Test_InitIntegration_InitDefaults(t *testing.T) {
 	f := NewFixture(t)
 	defer tearDownFixture(t, f)
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -99,9 +100,10 @@ func Test_InitIntegration_InitDefaults_CreateDefaultResources_False(t *testing.T
 	f := NewFixture(t)
 	defer tearDownFixture(t, f)
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		CreateDefaultResources: false,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    false,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -124,9 +126,10 @@ func Test_InitIntegration_BlueprintExists(t *testing.T) {
 		t.Errorf("Error creating Port blueprint: %s", err.Error())
 	}
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -150,9 +153,10 @@ func Test_InitIntegration_PageExists(t *testing.T) {
 		t.Errorf("Error creating Port page: %s", err.Error())
 	}
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -169,14 +173,15 @@ func Test_InitIntegration_PageExists(t *testing.T) {
 func Test_InitIntegration_ExistingIntegration(t *testing.T) {
 	f := NewFixture(t)
 	defer tearDownFixture(t, f)
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "", nil)
+	_, err := integration.CreateIntegration(f.portClient, f.stateKey, "", nil, false)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -189,7 +194,7 @@ func Test_InitIntegration_ExistingIntegration(t *testing.T) {
 func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
 	f := NewFixture(t)
 	defer tearDownFixture(t, f)
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "", nil)
+	_, err := integration.CreateIntegration(f.portClient, f.stateKey, "", nil, false)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}
@@ -214,10 +219,11 @@ func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
 		},
 	}
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "POLLING",
-		Resources:              expectedResources,
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		Resources:                 expectedResources,
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -231,15 +237,16 @@ func Test_InitIntegration_LocalResourcesConfiguration(t *testing.T) {
 func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_EmptyConfiguration(t *testing.T) {
 	f := NewFixture(t)
 	defer tearDownFixture(t, f)
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", nil)
+	_, err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", nil, false)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}
 	e := InitIntegration(f.portClient, &port.Config{
-		StateKey:               f.stateKey,
-		EventListenerType:      "KAFKA",
-		Resources:              nil,
-		CreateDefaultResources: true,
+		StateKey:                  f.stateKey,
+		EventListenerType:         "KAFKA",
+		Resources:                 nil,
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginK8S,
 	})
 	assert.Nil(t, e)
 
@@ -276,7 +283,7 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 			},
 		},
 	}
-	err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", expectedConfig)
+	_, err := integration.CreateIntegration(f.portClient, f.stateKey, "POLLING", expectedConfig, false)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}
@@ -287,6 +294,7 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 		EventListenerType:               "KAFKA",
 		Resources:                       expectedConfig.Resources,
 		CreateDefaultResources:          true,
+		CreatePortResourcesOrigin:       port.CreatePortResourcesOriginK8S,
 		OverwriteConfigurationOnRestart: true,
 	})
 	assert.Nil(t, e)
@@ -296,4 +304,21 @@ func Test_InitIntegration_LocalResourcesConfiguration_ExistingIntegration_WithCo
 	assert.Equal(t, expectedConfig.Resources, i.Config.Resources)
 
 	testUtils.CheckResourcesExistence(true, false, f.portClient, f.t, []string{"workload", "namespace", "cluster"}, []string{"workload_overview_dashboard", "availability_scorecard_dashboard"}, []string{})
+}
+
+func Test_InitIntegration_With_CreatePortResourcesOriginPort_FeatureFlag(t *testing.T) {
+	f := NewFixture(t)
+	defer tearDownFixture(t, f)
+
+	e := InitIntegration(f.portClient, &port.Config{
+		StateKey:                  f.stateKey,
+		EventListenerType:         "POLLING",
+		CreateDefaultResources:    true,
+		CreatePortResourcesOrigin: port.CreatePortResourcesOriginPort,
+	})
+	assert.Nil(t, e)
+
+	i, err := integration.GetIntegration(f.portClient, f.stateKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, i)
 }

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -63,7 +63,9 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 
 	if err != nil {
 		if applicationConfig.CreateDefaultResources {
-			defaultIntegrationConfig = defaults.AppConfig
+			if applicationConfig.CreatePortResourcesOrigin != port.CreatePortResourcesOriginPort {
+				defaultIntegrationConfig = defaults.AppConfig
+			}
 		}
 
 		klog.Warningf("Could not get integration with state key %s, error: %s", applicationConfig.StateKey, err.Error())
@@ -78,7 +80,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 			EventListener: getEventListenerConfig(applicationConfig.EventListenerType),
 		}
 
-		if existingIntegration.Config == nil || applicationConfig.OverwriteConfigurationOnRestart {
+		if (existingIntegration.Config == nil || applicationConfig.OverwriteConfigurationOnRestart) && !(applicationConfig.CreatePortResourcesOrigin == port.CreatePortResourcesOriginPort) {
 			integrationPatch.Config = defaultIntegrationConfig
 		}
 

--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -80,7 +80,7 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config)
 			EventListener: getEventListenerConfig(applicationConfig.EventListenerType),
 		}
 
-		if (existingIntegration.Config == nil || applicationConfig.OverwriteConfigurationOnRestart) && !(applicationConfig.CreatePortResourcesOrigin == port.CreatePortResourcesOriginPort) {
+		if (existingIntegration.Config == nil && !(applicationConfig.CreatePortResourcesOrigin == port.CreatePortResourcesOriginPort)) || applicationConfig.OverwriteConfigurationOnRestart {
 			integrationPatch.Config = defaultIntegrationConfig
 		}
 

--- a/pkg/event_handler/polling/polling_test.go
+++ b/pkg/event_handler/polling/polling_test.go
@@ -31,7 +31,6 @@ func (m *MockTicker) GetC() <-chan time.Time {
 
 func NewFixture(t *testing.T, c chan time.Time) *Fixture {
 	stateKey := guuid.NewString()
-
 	newConfig := &config.ApplicationConfiguration{
 		ConfigFilePath:                  config.ApplicationConfig.ConfigFilePath,
 		ResyncInterval:                  config.ApplicationConfig.ResyncInterval,
@@ -49,11 +48,10 @@ func NewFixture(t *testing.T, c chan time.Time) *Fixture {
 	}
 
 	portClient := cli.New(newConfig)
-
 	_ = integration.DeleteIntegration(portClient, stateKey)
-	err := integration.CreateIntegration(portClient, stateKey, "", &port.IntegrationAppConfig{
+	_, err := integration.CreateIntegration(portClient, stateKey, "", &port.IntegrationAppConfig{
 		Resources: []port.Resource{},
-	})
+	}, false)
 	if err != nil {
 		t.Errorf("Error creating Port integration: %s", err.Error())
 	}

--- a/pkg/port/cli/integration.go
+++ b/pkg/port/cli/integration.go
@@ -24,9 +24,10 @@ func parseIntegration(i *port.Integration) *port.Integration {
 	return x
 }
 
-func (c *PortClient) CreateIntegration(i *port.Integration) (*port.Integration, error) {
+func (c *PortClient) CreateIntegration(i *port.Integration, queryParams map[string]string) (*port.Integration, error) {
 	pb := &port.ResponseBody{}
 	resp, err := c.Client.R().
+		SetQueryParams(queryParams).
 		SetBody(parseIntegration(i)).
 		SetResult(&pb).
 		Post("v1/integration")

--- a/pkg/port/cli/org_details.go
+++ b/pkg/port/cli/org_details.go
@@ -23,3 +23,17 @@ func (c *PortClient) GetOrgId() (string, error) {
 	}
 	return pb.OrgDetails.OrgId, nil
 }
+
+func (c *PortClient) GetOrganizationFeatureFlags() ([]string, error) {
+	pb := &port.ResponseBody{}
+	resp, err := c.Client.R().
+		SetResult(&pb).
+		Get("v1/organization")
+	if err != nil {
+		return nil, err
+	}
+	if !pb.OK {
+		return nil, fmt.Errorf("failed to get organization feature flags, got: %s", resp.Body())
+	}
+	return pb.OrgDetails.FeatureFlags, nil
+}

--- a/pkg/port/integration/integration.go
+++ b/pkg/port/integration/integration.go
@@ -40,16 +40,14 @@ func CreateIntegration(portClient *cli.PortClient, stateKey string, eventListene
 	if err != nil {
 		return nil, fmt.Errorf("error authenticating with Port: %v", err)
 	}
-
+	queryParams := map[string]string{}
 	if createPortResourcesOriginInPort {
-		queryParams := map[string]string{
+		queryParams = map[string]string{
 			createResourcesParamName: strings.Join(createResourcesParamValue, ","),
 		}
-
-		portClient.Client.SetQueryParams(queryParams)
 	}
 
-	createdIntegration, err := portClient.CreateIntegration(integration)
+	createdIntegration, err := portClient.CreateIntegration(integration, queryParams)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Port integration: %v", err)
 	}
@@ -133,7 +131,7 @@ func PollIntegrationUntilDefaultProvisioningComplete(portClient *cli.PortClient,
 			return nil, fmt.Errorf("error getting integration during polling: %v", err)
 		}
 
-		if integration.Config != nil {
+		if integration.Config.Resources != nil {
 			return integration, nil
 		}
 

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -304,12 +304,24 @@ type IntegrationAppConfig struct {
 	SendRawDataExamples          *bool      `json:"sendRawDataExamples,omitempty"`
 }
 
+const (
+	OrgUseProvisionedDefaultsFeatureFlag = "USE_PROVISIONED_DEFAULTS"
+)
+
+type CreatePortResourcesOrigin string
+
+const (
+	CreatePortResourcesOriginPort CreatePortResourcesOrigin = "Port"
+	CreatePortResourcesOriginK8S  CreatePortResourcesOrigin = "K8S"
+)
+
 type Config struct {
-	ResyncInterval                  uint   `yaml:"resyncInterval,omitempty"`
-	StateKey                        string `yaml:"stateKey,omitempty"`
-	EventListenerType               string `yaml:"eventListenerType,omitempty"`
-	CreateDefaultResources          bool   `yaml:"createDefaultResources,omitempty"`
-	OverwriteConfigurationOnRestart bool   `yaml:"overwriteConfigurationOnRestart,omitempty"`
+	ResyncInterval                  uint                      `yaml:"resyncInterval,omitempty"`
+	StateKey                        string                    `yaml:"stateKey,omitempty"`
+	EventListenerType               string                    `yaml:"eventListenerType,omitempty"`
+	CreateDefaultResources          bool                      `yaml:"createDefaultResources,omitempty"`
+	CreatePortResourcesOrigin       CreatePortResourcesOrigin `yaml:"createPortResourcesOrigin,omitempty"`
+	OverwriteConfigurationOnRestart bool                      `yaml:"overwriteConfigurationOnRestart,omitempty"`
 	// These Configurations are used only for setting up the Integration on installation or when using OverwriteConfigurationOnRestart flag.
 	Resources                    []Resource `yaml:"resources,omitempty"`
 	CRDSToDiscover               string     `yaml:"crdsToDiscover,omitempty"`

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -207,7 +207,8 @@ type (
 	}
 
 	OrgDetails struct {
-		OrgId string `json:"id"`
+		OrgId        string   `json:"id"`
+		FeatureFlags []string `json:"featureFlags,omitempty"`
 	}
 )
 

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -19,3 +19,17 @@ func GetOrgId(portClient *cli.PortClient) (string, error) {
 
 	return r, nil
 }
+
+func GetOrganizationFeatureFlags(portClient *cli.PortClient) ([]string, error) {
+	_, err := portClient.Authenticate(context.Background(), portClient.ClientID, portClient.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("error authenticating with Port: %v", err)
+	}
+
+	flags, err := portClient.GetOrganizationFeatureFlags()
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization feature flags: %v", err)
+	}
+
+	return flags, nil
+}


### PR DESCRIPTION
# Description

What - Added support to create resources on port by default
Why -  Support onboarding experience
How - Decide which logic to execute by port FF

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

