### PR TITLE
add support for team search

### DIFF
--- a/pkg/jq/parser_test.go
+++ b/pkg/jq/parser_test.go
@@ -2,8 +2,9 @@ package jq
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	_ "github.com/port-labs/port-k8s-exporter/test_utils"
@@ -114,8 +115,8 @@ func TestJqSearchTeam(t *testing.T) {
 			},
 		},
 	}
-	res, _ = ParseMapRecursively(mapping[0].Team.(map[string]interface{}), nil)
-	assert.Equal(t, res, map[string]interface{}{
+	resMap, _ := ParseMapRecursively(mapping[0].Team.(map[string]interface{}), nil)
+	assert.Equal(t, resMap, map[string]interface{}{
 		"combinator": "and",
 		"rules": []interface{}{
 			map[string]interface{}{

--- a/pkg/jq/parser_test.go
+++ b/pkg/jq/parser_test.go
@@ -85,22 +85,9 @@ func TestJqSearchIdentifier(t *testing.T) {
 }
 
 func TestJqSearchTeam(t *testing.T) {
-	// Test with string type
 	mapping := []port.EntityMapping{
 		{
-			Identifier: ".metadata.name",
-			Blueprint:  fmt.Sprintf("\"%s\"", blueprint),
-			Icon:       "\"Microservice\"",
-			Team:       "\"Test\"",
-		},
-	}
-	res, _ := ParseString(mapping[0].Team.(string), nil)
-	assert.Equal(t, res, "Test")
-
-	// Test with map type
-	mapping = []port.EntityMapping{
-		{
-			Identifier: ".metadata.name",
+			Identifier: "\"Frontend-Service\"",
 			Blueprint:  fmt.Sprintf("\"%s\"", blueprint),
 			Icon:       "\"Microservice\"",
 			Team: map[string]interface{}{
@@ -108,21 +95,21 @@ func TestJqSearchTeam(t *testing.T) {
 				"rules": []interface{}{
 					map[string]interface{}{
 						"property": "\"team\"",
-						"operator": "\"=\"",
-						"value":    "\"Test\"",
+						"operator": "\"in\"",
+						"value":    ".values",
 					},
 				},
 			},
 		},
 	}
-	resMap, _ := ParseMapRecursively(mapping[0].Team.(map[string]interface{}), nil)
+	resMap, _ := ParseMapRecursively(mapping[0].Team.(map[string]interface{}), map[string]interface{}{"values": []string{"val1", "val2"}})
 	assert.Equal(t, resMap, map[string]interface{}{
 		"combinator": "and",
 		"rules": []interface{}{
 			map[string]interface{}{
 				"property": "team",
-				"operator": "=",
-				"value":    "Test",
+				"operator": "in",
+				"value":    []string{"val1", "val2"},
 			},
 		},
 	})

--- a/pkg/jq/parser_test.go
+++ b/pkg/jq/parser_test.go
@@ -82,3 +82,47 @@ func TestJqSearchIdentifier(t *testing.T) {
 	})
 
 }
+
+func TestJqSearchTeam(t *testing.T) {
+	// Test with string type
+	mapping := []port.EntityMapping{
+		{
+			Identifier: ".metadata.name",
+			Blueprint:  fmt.Sprintf("\"%s\"", blueprint),
+			Icon:       "\"Microservice\"",
+			Team:       "\"Test\"",
+		},
+	}
+	res, _ := ParseString(mapping[0].Team.(string), nil)
+	assert.Equal(t, res, "Test")
+
+	// Test with map type
+	mapping = []port.EntityMapping{
+		{
+			Identifier: ".metadata.name",
+			Blueprint:  fmt.Sprintf("\"%s\"", blueprint),
+			Icon:       "\"Microservice\"",
+			Team: map[string]interface{}{
+				"combinator": "\"and\"",
+				"rules": []interface{}{
+					map[string]interface{}{
+						"property": "\"team\"",
+						"operator": "\"=\"",
+						"value":    "\"Test\"",
+					},
+				},
+			},
+		},
+	}
+	res, _ = ParseMapRecursively(mapping[0].Team.(map[string]interface{}), nil)
+	assert.Equal(t, res, map[string]interface{}{
+		"combinator": "and",
+		"rules": []interface{}{
+			map[string]interface{}{
+				"property": "team",
+				"operator": "=",
+				"value":    "Test",
+			},
+		},
+	})
+}

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -129,6 +129,9 @@ func newFixture(t *testing.T, fixtureConfig *fixtureConfig) *fixture {
 	blueprintRaw := port.Blueprint{
 		Identifier: blueprintIdentifier,
 		Title:      blueprintIdentifier,
+		Ownership: {
+			"type": "Direct"
+		}
 		Schema: port.BlueprintSchema{
 			Properties: map[string]port.Property{
 				"bool": {

--- a/pkg/port/entity/entity.go
+++ b/pkg/port/entity/entity.go
@@ -105,8 +105,14 @@ func newEntityRequest(obj interface{}, mapping port.EntityMapping) (*port.Entity
 	if err != nil {
 		return nil, err
 	}
-	if mapping.Team != "" {
-		entity.Team, err = jq.ParseInterface(mapping.Team, obj)
+	if mapping.Team != nil {
+		if reflect.TypeOf(mapping.Team).Kind() == reflect.String {
+			entity.Team, err = jq.ParseString(mapping.Team.(string), obj)
+		} else if reflect.TypeOf(mapping.Team).Kind() == reflect.Map {
+			entity.Team, err = jq.ParseMapRecursively(mapping.Team.(map[string]interface{}), obj)
+		} else {
+			return nil, fmt.Errorf("invalid team type '%T'", mapping.Team)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -246,7 +246,7 @@ type EntityMapping struct {
 	Title      string                 `json:"title,omitempty" yaml:"title,omitempty"`
 	Blueprint  string                 `json:"blueprint" yaml:"blueprint"`
 	Icon       string                 `json:"icon,omitempty" yaml:"icon,omitempty"`
-	Team       string                 `json:"team,omitempty" yaml:"team,omitempty"`
+	Team       interface{}            `json:"team,omitempty" yaml:"team,omitempty"`
 	Properties map[string]string      `json:"properties,omitempty" yaml:"properties,omitempty"`
 	Relations  map[string]interface{} `json:"relations,omitempty" yaml:"relations,omitempty"`
 }

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -139,8 +139,13 @@ type (
 		MirrorProperties      map[string]BlueprintMirrorProperty      `json:"mirrorProperties,omitempty"`
 		ChangelogDestination  *ChangelogDestination                   `json:"changelogDestination,omitempty"`
 		Relations             map[string]Relation                     `json:"relations,omitempty"`
+		Ownership             *Ownership                              `json:"ownership,omitempty"`
 	}
 
+	Ownership struct {
+		Type string `json:"type,omitempty"`
+	}
+	
 	Page struct {
 		Identifier string      `json:"identifier"`
 		Blueprint  string      `json:"blueprint,omitempty"`

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -145,7 +145,7 @@ type (
 	Ownership struct {
 		Type string `json:"type,omitempty"`
 	}
-	
+
 	Page struct {
 		Identifier string      `json:"identifier"`
 		Blueprint  string      `json:"blueprint,omitempty"`
@@ -333,4 +333,8 @@ type Config struct {
 	OverwriteCRDsActions         bool       `yaml:"overwriteCrdsActions,omitempty"`
 	DeleteDependents             bool       `yaml:"deleteDependents,omitempty"`
 	CreateMissingRelatedEntities bool       `yaml:"createMissingRelatedEntities,omitempty"`
+}
+
+type Team struct {
+	Name string `json:"name"`
 }


### PR DESCRIPTION
# Description

What -Implement support for team search in the mapping
Why - With the new ownership model, team metadata property can be configured as a search query
How - Update the relevant code and add tests.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

