### PR TITLE
Prevent invalid-token failures by removing Authorization header in Authenticate

### DIFF
--- a/pkg/port/cli/client.go
+++ b/pkg/port/cli/client.go
@@ -53,8 +53,15 @@ func New(applicationConfig *config.ApplicationConfiguration, opts ...Option) *Po
 	return c
 }
 
+func (c *PortClient) ClearAuthToken() {
+	c.Client.SetAuthToken("")
+}
+
 func (c *PortClient) Authenticate(ctx context.Context, clientID, clientSecret string) (string, error) {
 	url := "v1/auth/access_token"
+
+	c.ClearAuthToken()
+
 	resp, err := c.Client.R().
 		SetBody(map[string]interface{}{
 			"clientId":     clientID,

--- a/pkg/port/cli/client.go
+++ b/pkg/port/cli/client.go
@@ -25,6 +25,7 @@ type (
 func New(applicationConfig *config.ApplicationConfiguration, opts ...Option) *PortClient {
 	c := &PortClient{
 		Client: resty.New().
+			SetDebug(true).
 			SetBaseURL(applicationConfig.PortBaseURL).
 			SetRetryCount(5).
 			SetRetryWaitTime(300).
@@ -60,6 +61,8 @@ func (c *PortClient) ClearAuthToken() {
 func (c *PortClient) Authenticate(ctx context.Context, clientID, clientSecret string) (string, error) {
 	url := "v1/auth/access_token"
 
+	// If the request to v1/auth/access_token is sent with an invalid token, traefik will return a 401 error.
+	// Since this is a public endpoint, we clear the existing token (if it does) to ensure the request is sent without it.
 	c.ClearAuthToken()
 
 	resp, err := c.Client.R().

--- a/pkg/port/cli/client.go
+++ b/pkg/port/cli/client.go
@@ -25,7 +25,6 @@ type (
 func New(applicationConfig *config.ApplicationConfiguration, opts ...Option) *PortClient {
 	c := &PortClient{
 		Client: resty.New().
-			SetDebug(true).
 			SetBaseURL(applicationConfig.PortBaseURL).
 			SetRetryCount(5).
 			SetRetryWaitTime(300).

--- a/pkg/port/cli/client.go
+++ b/pkg/port/cli/client.go
@@ -54,6 +54,7 @@ func New(applicationConfig *config.ApplicationConfiguration, opts ...Option) *Po
 }
 
 func (c *PortClient) ClearAuthToken() {
+	// Setting an empty token will remove the Authorization header from the request (see pkg/mod/github.com/go-resty/resty/v2@v2.7.0/middleware.go:255)
 	c.Client.SetAuthToken("")
 }
 

--- a/pkg/port/cli/client_test.go
+++ b/pkg/port/cli/client_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/port-labs/port-k8s-exporter/pkg/config"
+)
+
+// TestAuthenticate_RemovesAuthorizationHeader ensures that the Authenticate call does NOT
+// send an Authorization header – regardless of whether the underlying Resty client
+// already has one configured via SetAuthToken.
+func TestAuthenticate_RemovesAuthorizationHeader(t *testing.T) {
+	// Arrange an HTTP test server that records incoming requests.
+	var sawAuthHeader bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuthHeader = true
+		}
+		// Respond with a minimal valid payload.
+		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "new-token"})
+	}))
+	defer srv.Close()
+
+	// Build a PortClient pointing at the test server.
+	appCfg := &config.ApplicationConfiguration{
+		PortBaseURL:      srv.URL + "/", // Resty joins base URL + relative path.
+		PortClientId:     "test-id",
+		PortClientSecret: "test-secret",
+	}
+
+	pc := New(appCfg)
+
+	// Simulate a previously set token that would normally add an Authorization header.
+	pc.Client.SetAuthToken("old-token")
+
+	// Act – perform authentication.
+	_, err := pc.Authenticate(context.Background(), pc.ClientID, pc.ClientSecret)
+	if err != nil {
+		t.Fatalf("Authenticate returned error: %v", err)
+	}
+
+	// Assert – the server must not have observed an Authorization header.
+	if sawAuthHeader {
+		t.Fatalf("expected no Authorization header to be sent, but one was observed")
+	}
+}


### PR DESCRIPTION
# Description

What:
Clear any previously-set authentication token before the `POST /v1/auth/access_token` call in `pkg/port/cli/client.go`. This guarantees that the request is sent without an Authorization header.

Why:
When a stale or invalid bearer token is included in the Authorization header, Port’s API rejects the access-token request, returning 401. That blocks the exporter (and any other client) from recovering and refreshing its credentials.

How:
1. Implemented `ClearAuthToken`
2. Added a call to `ClearAuthToken` at the start of `Authenticate`.
3. Added a unit test (`TestAuthenticate_RemovesAuthorizationHeader`) to assert that no Authorization header is present.

## Type of change
Please leave one option from the following and delete the rest:
- [x] Bug fix (non-breaking change which fixes an issue)
