### PR TITLE
refresh token timer ticking logic fix

### DIFF
--- a/pkg/defaults/init.go
+++ b/pkg/defaults/init.go
@@ -90,12 +90,12 @@ func InitIntegration(portClient *cli.PortClient, applicationConfig *port.Config,
 			return err
 		}
 	}
-	logger.SetHttpWriterParametersAndStart(existingIntegration.LogAttributes.IngestUrl, func() (string, error) {
-		token, err := portClient.Authenticate(context.Background(), portClient.ClientID, portClient.ClientSecret)
+	logger.SetHttpWriterParametersAndStart(existingIntegration.LogAttributes.IngestUrl, func() (string, int, error) {
+		resp, err := portClient.GetAccessTokenResponse(context.Background(), portClient.ClientID, portClient.ClientSecret)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
-		return token, nil
+		return resp.AccessToken, int(resp.ExpiresIn), nil
 	}, logger.LoggerIntegrationData{
 		IntegrationVersion:    existingIntegration.Version,
 		IntegrationIdentifier: existingIntegration.Identifier,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -210,13 +210,15 @@ func (w *HTTPWriter) refreshTokenTimer(authFunc func() (string, error), expiresI
 	for {
 		select {
 		case <-ticker.C:
-			w.mu.Lock()
-			defer w.mu.Unlock()
-			token, err := authFunc()
-			if err != nil {
-				return
-			}
-			w.Client = w.Client.SetAuthScheme("Bearer").SetAuthToken(token)
+			func() {
+				w.mu.Lock()
+				defer w.mu.Unlock()
+				token, err := authFunc()
+				if err != nil {
+					return
+				}
+				w.Client = w.Client.SetAuthScheme("Bearer").SetAuthToken(token)
+			}()
 		case <-w.done:
 			return
 		case <-w.ctx.Done():

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -47,8 +47,8 @@ func TestHTTPWriter(t *testing.T) {
 	// Start the background goroutines
 	writer.wg.Add(2)
 	go writer.flushTimer()
-	go writer.refreshTokenTimer(func() (string, error) {
-		return "test-token", nil
+	go writer.refreshTokenTimer(func() (string, int, error) {
+		return "test-token", 10, nil
 	}, time.Minute*1)
 
 	testLog := `{"level":"info","timestamp":"2024-01-01T00:00:00.000Z","message":"test message"}`
@@ -109,8 +109,8 @@ func TestInitWithHTTP(t *testing.T) {
 		httpWriter.Capacity = 1
 		httpWriter.FlushInterval = 100 * time.Millisecond
 
-		SetHttpWriterParametersAndStart(server.URL, func() (string, error) {
-			return "test-token", nil
+		SetHttpWriterParametersAndStart(server.URL, func() (string, int, error) {
+			return "test-token", 10, nil
 		}, LoggerIntegrationData{
 			IntegrationVersion:    "1.0.0",
 			IntegrationIdentifier: "test",
@@ -180,8 +180,8 @@ func TestInitWithLevelAndHTTP(t *testing.T) {
 		httpWriter.Capacity = 1
 		httpWriter.FlushInterval = 100 * time.Millisecond
 
-		SetHttpWriterParametersAndStart(server.URL, func() (string, error) {
-			return "test-token", nil
+		SetHttpWriterParametersAndStart(server.URL, func() (string, int, error) {
+			return "test-token", 10, nil
 		}, LoggerIntegrationData{
 			IntegrationVersion:    "1.0.0",
 			IntegrationIdentifier: "test",
@@ -226,8 +226,8 @@ func TestHTTPWriterFailureHandling(t *testing.T) {
 	// Start the background goroutines
 	writer.wg.Add(2)
 	go writer.flushTimer()
-	go writer.refreshTokenTimer(func() (string, error) {
-		return "test-token", nil
+	go writer.refreshTokenTimer(func() (string, int, error) {
+		return "test-token", 10, nil
 	}, time.Minute*1)
 
 	testLog := `{"level":"info","message":"test"}`


### PR DESCRIPTION

# Description

What - Wrap the refresh token timed logic with function to fix defer behavior
Why - Possible deadlock which cause pods to stuck
How - 

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

