### PR TITLE
Add itemsToParseName support

### DIFF
--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -668,6 +668,11 @@ func isPassSelector(obj interface{}, selector port.Selector) (bool, error) {
 }
 
 func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping, itemsToParse string, itemsToParseName string, kindIndex int) ([]port.EntityRequest, []interface{}, error) {
+	// Set default value for itemsToParseName if empty
+	if itemsToParseName == "" {
+		itemsToParseName = "item"
+	}
+
 	transformResult, err := metrics.MeasureDuration(metrics.GetKindLabel(c.Resource.Kind, nil), metrics.MetricPhaseTransform, func(phase string) (*TransformResult, error) {
 		kindLabel := metrics.GetKindLabel(c.Resource.Kind, &kindIndex)
 		var result TransformResult

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -466,7 +466,7 @@ func (c *Controller) processNextWorkItemWithBatching(workqueue workqueue.RateLim
 		rawDataExamples := make([]interface{}, 0)
 		kindConfig := c.Resource.KindConfigs[item.KindIndex]
 		kindLabel := metrics.GetKindLabel(c.Resource.Kind, &item.KindIndex)
-		portEntities, rawDataExamplesForObj, err := c.getObjectEntities(k8sObj, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, item.KindIndex)
+		portEntities, rawDataExamplesForObj, err := c.getObjectEntities(k8sObj, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindConfig.Port.ItemsToParseName, item.KindIndex)
 		if err != nil {
 			logger.Errorw(fmt.Sprintf("Error getting entities for object %s. Error: %s", item.Key, err.Error()), "key", item.Key, "controller", c.Resource.Kind, "error", err, "eventSource", item.EventSource)
 			logger.Debugw("Marking batch collector as having errors", "controller", c.Resource.Kind)
@@ -612,7 +612,7 @@ func (c *Controller) objectHandler(obj interface{}, item EventItem) (*SyncResult
 
 	for kindIndex, kindConfig := range c.Resource.KindConfigs {
 		logger.Debugw("Getting entities for object", "key", item.Key, "resource", c.Resource.Kind, "eventSource", item.EventSource)
-		portEntities, rawDataExamples, err := c.getObjectEntities(obj, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindIndex)
+		portEntities, rawDataExamples, err := c.getObjectEntities(obj, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindConfig.Port.ItemsToParseName, kindIndex)
 		if err != nil {
 			logger.Errorw(fmt.Sprintf("error getting entities. Error: %s", err.Error()), "key", item.Key, "resource", c.Resource.Kind, "error", err, "eventSource", item.EventSource)
 			entitiesSet = nil
@@ -667,7 +667,11 @@ func isPassSelector(obj interface{}, selector port.Selector) (bool, error) {
 	return selectorResult, err
 }
 
-func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping, itemsToParse string, kindIndex int) ([]port.EntityRequest, []interface{}, error) {
+func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping, itemsToParse string, itemsToParseName string, kindIndex int) ([]port.EntityRequest, []interface{}, error) {
+	// Set default value for itemsToParseName if empty
+	if itemsToParseName == "" {
+		itemsToParseName = "item"
+	}
 	transformResult, err := metrics.MeasureDuration(metrics.GetKindLabel(c.Resource.Kind, nil), metrics.MetricPhaseTransform, func(phase string) (*TransformResult, error) {
 		kindLabel := metrics.GetKindLabel(c.Resource.Kind, &kindIndex)
 		var result TransformResult
@@ -703,7 +707,7 @@ func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, 
 				for key, value := range mappedObject {
 					copiedObject[key] = value
 				}
-				copiedObject["item"] = item
+				copiedObject[itemsToParseName] = item
 				objectsToMap = append(objectsToMap, copiedObject)
 			}
 		}
@@ -782,12 +786,12 @@ func (c *Controller) shouldSendUpdateEvent(old interface{}, new interface{}, upd
 		return true
 	}
 	for kindIndex, kindConfig := range c.Resource.KindConfigs {
-		oldEntities, _, err := c.getObjectEntities(old, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindIndex)
+		oldEntities, _, err := c.getObjectEntities(old, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindConfig.Port.ItemsToParseName, kindIndex)
 		if err != nil {
 			logger.Errorf("Error getting old entities: %v", err)
 			return true
 		}
-		newEntities, _, err := c.getObjectEntities(new, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindIndex)
+		newEntities, _, err := c.getObjectEntities(new, kindConfig.Selector, kindConfig.Port.Entity.Mappings, kindConfig.Port.ItemsToParse, kindConfig.Port.ItemsToParseName, kindIndex)
 		if err != nil {
 			logger.Errorf("Error getting new entities: %v", err)
 			return true

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -668,10 +668,6 @@ func isPassSelector(obj interface{}, selector port.Selector) (bool, error) {
 }
 
 func (c *Controller) getObjectEntities(obj interface{}, selector port.Selector, mappings []port.EntityMapping, itemsToParse string, itemsToParseName string, kindIndex int) ([]port.EntityRequest, []interface{}, error) {
-	// Set default value for itemsToParseName if empty
-	if itemsToParseName == "" {
-		itemsToParseName = "item"
-	}
 	transformResult, err := metrics.MeasureDuration(metrics.GetKindLabel(c.Resource.Kind, nil), metrics.MetricPhaseTransform, func(phase string) (*TransformResult, error) {
 		kindLabel := metrics.GetKindLabel(c.Resource.Kind, &kindIndex)
 		var result TransformResult

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -53,6 +53,7 @@ type fixtureConfig struct {
 	sendRawDataExamples *bool
 	resource            port.Resource
 	existingObjects     []runtime.Object
+	blueprint           *port.Blueprint
 }
 
 func tearDownFixture(
@@ -125,31 +126,36 @@ func newFixture(t *testing.T, fixtureConfig *fixtureConfig) *fixture {
 	kubeClient := k8sfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), newGvrToListKind(), fixtureConfig.existingObjects...)
 	controller := newController(t, fixtureConfig.resource, kubeClient, interationConfig, newConfig)
 
-	blueprintRaw := port.Blueprint{
-		Identifier: blueprintIdentifier,
-		Title:      blueprintIdentifier,
-		Ownership: &port.Ownership{
-			Type: "Direct",
-		},
-		Schema: port.BlueprintSchema{
-			Properties: map[string]port.Property{
-				"bool": {
-					Type: "boolean",
-				},
-				"text": {
-					Type: "string",
-				},
-				"num": {
-					Type: "number",
-				},
-				"obj": {
-					Type: "object",
-				},
-				"arr": {
-					Type: "array",
+	var blueprintRaw port.Blueprint
+	if fixtureConfig.blueprint != nil {
+		blueprintRaw = *fixtureConfig.blueprint
+	} else {
+		blueprintRaw = port.Blueprint{
+			Identifier: blueprintIdentifier,
+			Title:      blueprintIdentifier,
+			Ownership: &port.Ownership{
+				Type: "Direct",
+			},
+			Schema: port.BlueprintSchema{
+				Properties: map[string]port.Property{
+					"bool": {
+						Type: "boolean",
+					},
+					"text": {
+						Type: "string",
+					},
+					"num": {
+						Type: "number",
+					},
+					"obj": {
+						Type: "object",
+					},
+					"arr": {
+						Type: "array",
+					},
 				},
 			},
-		},
+		}
 	}
 
 	t.Logf("creating blueprint %s", blueprintIdentifier)
@@ -837,6 +843,107 @@ func TestCreateDeploymentWithSearchRelation(t *testing.T) {
 	defer tearDownFixture(t, f)
 	f.runControllerSyncHandler(item, &SyncResult{EntitiesSet: map[string]interface{}{fmt.Sprintf("%s;%s", blueprintId, d.Name): nil}, RawDataExamples: []interface{}{ud.Object}, ShouldDeleteStaleEntities: true}, false)
 } */
+
+func newBlueprintWithContainerName(blueprintId string) port.Blueprint {
+	return port.Blueprint{
+		Identifier: blueprintId,
+		Title:      blueprintId,
+		Ownership: &port.Ownership{
+			Type: "Direct",
+		},
+		Schema: port.BlueprintSchema{
+			Properties: map[string]port.Property{
+				"bool": {
+					Type: "boolean",
+				},
+				"text": {
+					Type: "string",
+				},
+				"num": {
+					Type: "number",
+				},
+				"obj": {
+					Type: "object",
+				},
+				"arr": {
+					Type: "array",
+				},
+				"containerName": {
+					Type: "string",
+				},
+			},
+		},
+	}
+}
+
+func TestItemsToParseName(t *testing.T) {
+	stateKey := guuid.NewString()
+	blueprintId := getBlueprintId(stateKey)
+	d := newDeployment(stateKey)
+	ud := newUnstructured(d)
+
+	// Without itemsToParseName (should default to "item")
+	resource := getBaseDeploymentResource(stateKey)
+	resource.Port.ItemsToParse = ".spec.template.spec.containers"
+	resource.Port.Entity.Mappings[0].Properties["containerName"] = ".item.name"
+
+	blueprint := newBlueprintWithContainerName(blueprintId)
+	f := newFixture(t, &fixtureConfig{
+		stateKey:        stateKey,
+		resource:        resource,
+		existingObjects: []runtime.Object{ud},
+		blueprint:       &blueprint,
+	})
+	defer tearDownFixture(t, f)
+
+	item := EventItem{Key: getKey(d, t), ActionType: CreateAction}
+	_, err := f.controller.syncHandler(item)
+	if err != nil {
+		t.Errorf("error syncing item: %v", err)
+	}
+
+	// Verify the container name was correctly extracted using default "item"
+	entity, err := f.controller.portClient.ReadEntity(context.Background(), d.Name, blueprintId)
+	if err != nil {
+		t.Errorf("error reading entity: %v", err)
+	}
+	assert.Equal(t, d.Name, entity.Properties["containerName"])
+}
+
+func TestItemsToParseNameCustom(t *testing.T) {
+	stateKey := guuid.NewString()
+	blueprintId := getBlueprintId(stateKey)
+	d := newDeployment(stateKey)
+	ud := newUnstructured(d)
+
+	// With custom itemsToParseName
+	resource := getBaseDeploymentResource(stateKey)
+	resource.Port.ItemsToParse = ".spec.template.spec.containers"
+	resource.Port.ItemsToParseName = "container"
+	resource.Port.Entity.Mappings[0].Properties["containerName"] = ".container.name"
+
+	blueprint := newBlueprintWithContainerName(blueprintId)
+	f := newFixture(t, &fixtureConfig{
+		stateKey:        stateKey,
+		resource:        resource,
+		existingObjects: []runtime.Object{ud},
+		blueprint:       &blueprint,
+	})
+	defer tearDownFixture(t, f)
+
+	item := EventItem{Key: getKey(d, t), ActionType: CreateAction}
+	_, err := f.controller.syncHandler(item)
+	if err != nil {
+		t.Errorf("error syncing item: %v", err)
+	}
+
+	// Verify the container name was correctly extracted using custom "container"
+	entity, err := f.controller.portClient.ReadEntity(context.Background(), d.Name, blueprintId)
+	if err != nil {
+		t.Errorf("error reading entity: %v", err)
+	}
+	assert.Equal(t, d.Name, entity.Properties["containerName"])
+}
 
 func TestCreateDeploymentWithTeamString(t *testing.T) {
 	stateKey := guuid.NewString()

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -882,7 +882,6 @@ func TestItemsToParseName(t *testing.T) {
 	d := newDeployment(stateKey)
 	ud := newUnstructured(d)
 
-	// Without itemsToParseName (should default to "item")
 	resource := getBaseDeploymentResource(stateKey)
 	resource.Port.ItemsToParse = ".spec.template.spec.containers"
 	resource.Port.Entity.Mappings[0].Properties["containerName"] = ".item.name"
@@ -916,7 +915,6 @@ func TestItemsToParseNameCustom(t *testing.T) {
 	d := newDeployment(stateKey)
 	ud := newUnstructured(d)
 
-	// With custom itemsToParseName
 	resource := getBaseDeploymentResource(stateKey)
 	resource.Port.ItemsToParse = ".spec.template.spec.containers"
 	resource.Port.ItemsToParseName = "container"

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -317,6 +317,7 @@ type EntityMappings struct {
 type Port struct {
 	Entity       EntityMappings `json:"entity" yaml:"entity"`
 	ItemsToParse string         `json:"itemsToParse,omitempty" yaml:"itemsToParse"`
+	ItemsToParseName string         `json:"itemsToParseName,omitempty" yaml:"itemsToParseName" default:"item"`
 }
 
 type Selector struct {

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -315,9 +315,9 @@ type EntityMappings struct {
 }
 
 type Port struct {
-	Entity       EntityMappings `json:"entity" yaml:"entity"`
-	ItemsToParse string         `json:"itemsToParse,omitempty" yaml:"itemsToParse"`
-	ItemsToParseName string         `json:"itemsToParseName,omitempty" yaml:"itemsToParseName" default:"item"`
+	Entity           EntityMappings `json:"entity" yaml:"entity"`
+	ItemsToParse     string         `json:"itemsToParse,omitempty" yaml:"itemsToParse"`
+	ItemsToParseName string         `json:"itemsToParseName,omitempty" yaml:"itemsToParseName"`
 }
 
 type Selector struct {


### PR DESCRIPTION
# Description

What - Added support for the `itemsToParseName` param, to allow mapping item context to another key name upon jq parse

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

