### PR TITLE
update polling event listener to query from resync requests as well

### DIFF
--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -75,6 +75,7 @@ func shouldResync(lastUpdatedAt string, lastIntegrationStateUpdatedAt string) bo
 	if lastIntegrationStateUpdatedAt == "" {
 		return true
 	}
+	
 	return lastIntegrationStateUpdatedAt != lastUpdatedAt
 }
 

--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -1,15 +1,17 @@
 package polling
 
 import (
+	"errors"
 	"os"
 	"os/signal"
-	"reflect"
+	"slices"
 	"syscall"
 	"time"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/logger"
+	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
-	"github.com/port-labs/port-k8s-exporter/pkg/port/integration"
+	"github.com/port-labs/port-k8s-exporter/pkg/port/org_details"
 )
 
 type ITicker interface {
@@ -35,10 +37,13 @@ func (t *Ticker) GetC() <-chan time.Time {
 }
 
 type Handler struct {
-	ticker      ITicker
-	stateKey    string
-	portClient  *cli.PortClient
-	pollingRate uint
+	ticker                           ITicker
+	stateKey                         string
+	portClient                       *cli.PortClient
+	pollingRate                      uint
+	lastIntegrationStateUpdatedAt    string
+	lastResyncRequestUpdatedAt            string
+	resyncRequestsPollingEnabled          *bool
 }
 
 func NewPollingHandler(pollingRate uint, stateKey string, portClient *cli.PortClient, tickerOverride ITicker) *Handler {
@@ -55,11 +60,128 @@ func NewPollingHandler(pollingRate uint, stateKey string, portClient *cli.PortCl
 	return rv
 }
 
+func formatUpdatedAt(updatedAt *time.Time) string {
+	if updatedAt == nil {
+		return ""
+	}
+	return updatedAt.UTC().Format(time.RFC3339Nano)
+}
+
+func shouldResync(lastUpdatedAt string, lastIntegrationStateUpdatedAt string) bool {
+	if lastIntegrationStateUpdatedAt == "" {
+		return false
+	}
+	return lastIntegrationStateUpdatedAt != lastUpdatedAt
+}
+
+func shouldResyncFromResyncRequest(resyncRequestUpdatedAt string, lastProcessedResyncRequestUpdatedAt string) bool {
+	if resyncRequestUpdatedAt == "" {
+		return false
+	}
+
+	resyncRequestTime, err := parsePortTimestamp(resyncRequestUpdatedAt)
+	if err != nil {
+		return false
+	}
+
+	if lastProcessedResyncRequestUpdatedAt == "" {
+		return true
+	}
+
+	lastProcessedTime, err := parsePortTimestamp(lastProcessedResyncRequestUpdatedAt)
+	if err != nil {
+		return true
+	}
+
+	return lastProcessedTime.Before(resyncRequestTime)
+}
+
+func parsePortTimestamp(value string) (time.Time, error) {
+	layouts := []string{time.RFC3339Nano, time.RFC3339}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, errors.New("invalid timestamp format")
+}
+
+func (h *Handler) isResyncRequestsPollingEnabled() bool {
+	if h.resyncRequestsPollingEnabled != nil {
+		return *h.resyncRequestsPollingEnabled
+	}
+
+	enabled := false
+	flags, err := org_details.GetOrganizationFeatureFlags(h.portClient)
+	if err != nil {
+		logger.Errorw(
+			"Failed to fetch organization feature flags for resync request polling, disabling resync request polling",
+			"error", err.Error(),
+		)
+	} else {
+		enabled = slices.Contains(flags, port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag)
+	}
+
+	h.resyncRequestsPollingEnabled = &enabled
+	return enabled
+}
+
+func (h *Handler) pollIteration(resync func()) {
+	logger.Infof("Polling event listener iteration after %d seconds. Checking for changes...", h.pollingRate)
+
+	integration, err := h.portClient.GetIntegrationForPolling(h.stateKey)
+	if err != nil {
+		logger.Errorw(
+			"Failed to fetch current integration in polling listener, skipping iteration",
+			"error", err.Error(),
+		)
+		return
+	}
+
+	lastUpdatedAt := formatUpdatedAt(integration.UpdatedAt)
+	shouldTriggerResync := shouldResync(lastUpdatedAt, h.lastIntegrationStateUpdatedAt)
+	resyncReason := "Detected change in integration, resyncing"
+	resyncRequestUpdatedAt := ""
+
+	if !shouldTriggerResync && h.isResyncRequestsPollingEnabled() {
+		resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
+		if err != nil {
+			logger.Errorw(
+				"Failed to fetch integration resync request in polling listener, continuing without resync request signal",
+				"error", err.Error(),
+			)
+		} else if resyncRequest != nil {
+			resyncRequestUpdatedAt = formatUpdatedAt(resyncRequest.UpdatedAt)
+			shouldTriggerResync = shouldResyncFromResyncRequest(
+				resyncRequestUpdatedAt,
+				h.lastResyncRequestUpdatedAt,
+			)
+			if shouldTriggerResync {
+				resyncReason = "Detected integration resync request"
+			}
+		}
+	}
+
+	if !shouldTriggerResync {
+		return
+	}
+
+	logger.Info(resyncReason)
+	h.lastIntegrationStateUpdatedAt = lastUpdatedAt
+	if resyncRequestUpdatedAt != "" {
+		h.lastResyncRequestUpdatedAt = resyncRequestUpdatedAt
+	}
+	resync()
+}
+
 func (h *Handler) Run(resync func()) {
 	logger.Infof("Starting polling handler")
-	currentState, err := integration.GetIntegration(h.portClient, h.stateKey)
+
+	integration, err := h.portClient.GetIntegrationForPolling(h.stateKey)
 	if err != nil {
-		logger.Errorf("Error fetching the first AppConfig state: %s", err.Error())
+		logger.Errorf("Error fetching the first integration state: %s", err.Error())
+	} else {
+		h.lastIntegrationStateUpdatedAt = formatUpdatedAt(integration.UpdatedAt)
 	}
 
 	sigChan := make(chan os.Signal, 1)
@@ -71,19 +193,10 @@ func (h *Handler) Run(resync func()) {
 		select {
 		case sig := <-sigChan:
 			logger.Infof("Received signal %v: terminating\n", sig)
-			// Flush any pending logs before termination
 			logger.Shutdown()
 			run = false
 		case <-h.ticker.GetC():
-			logger.Infof("Polling event listener iteration after %d seconds. Checking for changes...", h.pollingRate)
-			configuration, err := integration.GetIntegration(h.portClient, h.stateKey)
-			if err != nil {
-				logger.Errorf("error getting integration: %s", err.Error())
-			} else if reflect.DeepEqual(currentState, configuration) != true {
-				logger.Infof("Changes detected. Resyncing...")
-				currentState = configuration
-				resync()
-			}
+			h.pollIteration(resync)
 		}
 	}
 }

--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -68,8 +68,12 @@ func formatUpdatedAt(updatedAt *time.Time) string {
 }
 
 func shouldResync(lastUpdatedAt string, lastIntegrationStateUpdatedAt string) bool {
-	if lastIntegrationStateUpdatedAt == "" {
+	if lastUpdatedAt == "" {
 		return false
+	}
+	
+	if lastIntegrationStateUpdatedAt == "" {
+		return true
 	}
 	return lastIntegrationStateUpdatedAt != lastUpdatedAt
 }
@@ -111,17 +115,16 @@ func (h *Handler) isResyncRequestsPollingEnabled() bool {
 		return *h.resyncRequestsPollingEnabled
 	}
 
-	enabled := false
 	flags, err := org_details.GetOrganizationFeatureFlags(h.portClient)
 	if err != nil {
 		logger.Errorw(
-			"Failed to fetch organization feature flags for resync request polling, disabling resync request polling",
+			"Failed to fetch organization feature flags for resync request polling, skipping resync request polling for this iteration",
 			"error", err.Error(),
 		)
-	} else {
-		enabled = slices.Contains(flags, port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag)
+		return false
 	}
 
+	enabled := slices.Contains(flags, port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag)
 	h.resyncRequestsPollingEnabled = &enabled
 	return enabled
 }

--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -42,8 +42,8 @@ type Handler struct {
 	portClient                       *cli.PortClient
 	pollingRate                      uint
 	lastIntegrationStateUpdatedAt    string
-	lastResyncRequestUpdatedAt            string
-	resyncRequestsPollingEnabled          *bool
+	lastResyncRequestUpdatedAt       string
+	resyncRequestsPollingEnabled     *bool
 }
 
 func NewPollingHandler(pollingRate uint, stateKey string, portClient *cli.PortClient, tickerOverride ITicker) *Handler {

--- a/pkg/event_handler/polling/polling_resync_request_test.go
+++ b/pkg/event_handler/polling/polling_resync_request_test.go
@@ -1,0 +1,379 @@
+package polling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/port-labs/port-k8s-exporter/pkg/config"
+	"github.com/port-labs/port-k8s-exporter/pkg/port"
+	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type resyncPollingTestServer struct {
+	t                    *testing.T
+	stateKey             string
+	featureFlags         []string
+	integrationUpdatedAt time.Time
+	resyncRequestUpdatedAt *time.Time
+
+	mu                     sync.Mutex
+	resyncRequestCallCount int
+}
+
+func newResyncPollingTestServer(t *testing.T, cfg resyncPollingTestServer) *resyncPollingTestServer {
+	t.Helper()
+	return &cfg
+}
+
+func (s *resyncPollingTestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case r.URL.Path == "/v1/auth/access_token":
+		_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
+			AccessToken: "test-token",
+			ExpiresIn:   3600,
+		})
+	case r.URL.Path == "/v1/organization":
+		_ = json.NewEncoder(w).Encode(port.ResponseBody{
+			OK: true,
+			OrgDetails: port.OrgDetails{
+				OrgId:        "test-org",
+				FeatureFlags: s.featureFlags,
+			},
+		})
+	case r.URL.Path == "/v1/integration/"+s.stateKey:
+		_ = json.NewEncoder(w).Encode(port.ResponseBody{
+			OK: true,
+			Integration: port.Integration{
+				UpdatedAt: &s.integrationUpdatedAt,
+			},
+		})
+	case r.URL.Path == "/v1/integration/"+s.stateKey+"/resync-request":
+		s.mu.Lock()
+		s.resyncRequestCallCount++
+		s.mu.Unlock()
+
+		var request *port.IntegrationResyncTriggerRequest
+		if s.resyncRequestUpdatedAt != nil {
+			updatedAt := *s.resyncRequestUpdatedAt
+			request = &port.IntegrationResyncTriggerRequest{UpdatedAt: &updatedAt}
+		}
+		_ = json.NewEncoder(w).Encode(struct {
+			OK      bool                                 `json:"ok"`
+			Request *port.IntegrationResyncTriggerRequest `json:"request"`
+		}{
+			OK:      true,
+			Request: request,
+		})
+	default:
+		s.t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}
+}
+
+func (s *resyncPollingTestServer) ResyncRequestCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resyncRequestCallCount
+}
+
+func newTestPollingHandler(t *testing.T, mock *resyncPollingTestServer) (*Handler, *httptest.Server) {
+	t.Helper()
+
+	server := httptest.NewServer(mock)
+	t.Cleanup(server.Close)
+
+	portClient := cli.New(&config.ApplicationConfiguration{
+		PortBaseURL:      server.URL,
+		PortClientId:     "test-client-id",
+		PortClientSecret: "test-client-secret",
+		StateKey:         mock.stateKey,
+	})
+
+	return NewPollingHandler(1, mock.stateKey, portClient, nil), server
+}
+
+func TestPollIteration_ResyncRequestPolling(t *testing.T) {
+	integrationUpdatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	resyncRequestUpdatedAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	olderResyncRequestUpdatedAt := time.Date(2026, 1, 1, 6, 0, 0, 0, time.UTC)
+	stateKey := "test-state-key"
+
+	tests := []struct {
+		name                         string
+		featureFlags                 []string
+		resyncRequestUpdatedAt       *time.Time
+		lastResyncRequestWatermark   string
+		expectResync                 bool
+		expectResyncRequestFetched   bool
+	}{
+		{
+			name:                       "feature flag disabled skips resync request polling",
+			featureFlags:               []string{},
+			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
+			lastResyncRequestWatermark: "",
+			expectResync:               false,
+			expectResyncRequestFetched: false,
+		},
+		{
+			name: "feature flag enabled triggers resync when resync request advances",
+			featureFlags: []string{
+				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
+			},
+			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
+			lastResyncRequestWatermark: "",
+			expectResync:               true,
+			expectResyncRequestFetched: true,
+		},
+		{
+			name: "feature flag enabled does not resync when watermark matches resync request",
+			featureFlags: []string{
+				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
+			},
+			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
+			lastResyncRequestWatermark: formatUpdatedAt(&resyncRequestUpdatedAt),
+			expectResync:               false,
+			expectResyncRequestFetched: true,
+		},
+		{
+			name: "feature flag enabled does not resync when resync request is older than watermark",
+			featureFlags: []string{
+				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
+			},
+			resyncRequestUpdatedAt:     &olderResyncRequestUpdatedAt,
+			lastResyncRequestWatermark: formatUpdatedAt(&resyncRequestUpdatedAt),
+			expectResync:               false,
+			expectResyncRequestFetched: true,
+		},
+		{
+			name: "feature flag enabled does not resync when resync request is missing",
+			featureFlags: []string{
+				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
+			},
+			resyncRequestUpdatedAt:     nil,
+			lastResyncRequestWatermark: "",
+			expectResync:               false,
+			expectResyncRequestFetched: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := newResyncPollingTestServer(t, resyncPollingTestServer{
+				t:                      t,
+				stateKey:               stateKey,
+				featureFlags:           tt.featureFlags,
+				integrationUpdatedAt:   integrationUpdatedAt,
+				resyncRequestUpdatedAt: tt.resyncRequestUpdatedAt,
+			})
+
+			handler, _ := newTestPollingHandler(t, mock)
+			handler.lastIntegrationStateUpdatedAt = formatUpdatedAt(&integrationUpdatedAt)
+			handler.lastResyncRequestUpdatedAt = tt.lastResyncRequestWatermark
+
+			resyncCalled := false
+			handler.pollIteration(func() {
+				resyncCalled = true
+			})
+
+			assert.Equal(t, tt.expectResync, resyncCalled)
+			assert.Equal(t, tt.expectResyncRequestFetched, mock.ResyncRequestCallCount() > 0)
+
+			if tt.expectResync {
+				assert.Equal(t, formatUpdatedAt(tt.resyncRequestUpdatedAt), handler.lastResyncRequestUpdatedAt)
+			} else {
+				assert.Equal(t, tt.lastResyncRequestWatermark, handler.lastResyncRequestUpdatedAt)
+			}
+		})
+	}
+}
+
+func TestPollIteration_ResyncRequestWatermarkAdvancesAcrossIterations(t *testing.T) {
+	stateKey := "test-state-key"
+	integrationUpdatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	firstResyncRequestAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+	secondResyncRequestAt := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+
+	mock := &resyncPollingTestServer{
+		t:                    t,
+		stateKey:             stateKey,
+		featureFlags:         []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
+		integrationUpdatedAt: integrationUpdatedAt,
+		resyncRequestUpdatedAt: &firstResyncRequestAt,
+	}
+
+	handler, _ := newTestPollingHandler(t, mock)
+	handler.lastIntegrationStateUpdatedAt = formatUpdatedAt(&integrationUpdatedAt)
+
+	firstResyncCalled := false
+	handler.pollIteration(func() {
+		firstResyncCalled = true
+	})
+	require.True(t, firstResyncCalled)
+	assert.Equal(t, formatUpdatedAt(&firstResyncRequestAt), handler.lastResyncRequestUpdatedAt)
+
+	secondResyncCalled := false
+	handler.pollIteration(func() {
+		secondResyncCalled = true
+	})
+	assert.False(t, secondResyncCalled, "same resync-request timestamp should not trigger another resync")
+
+	mock.mu.Lock()
+	mock.resyncRequestUpdatedAt = &secondResyncRequestAt
+	mock.mu.Unlock()
+
+	thirdResyncCalled := false
+	handler.pollIteration(func() {
+		thirdResyncCalled = true
+	})
+	require.True(t, thirdResyncCalled, "advanced resync-request timestamp should trigger resync")
+	assert.Equal(t, formatUpdatedAt(&secondResyncRequestAt), handler.lastResyncRequestUpdatedAt)
+}
+
+func TestIsResyncRequestsPollingEnabled_CachesOnlyOnSuccess(t *testing.T) {
+	stateKey := "test-state-key"
+	orgRequestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/v1/auth/access_token":
+			_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
+				AccessToken: "test-token",
+				ExpiresIn:   3600,
+			})
+		case r.URL.Path == "/v1/organization":
+			orgRequestCount++
+			if orgRequestCount == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"ok": false}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(port.ResponseBody{
+				OK: true,
+				OrgDetails: port.OrgDetails{
+					OrgId: "test-org",
+					FeatureFlags: []string{
+						port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	portClient := cli.New(&config.ApplicationConfiguration{
+		PortBaseURL:      server.URL,
+		PortClientId:     "test-client-id",
+		PortClientSecret: "test-client-secret",
+		StateKey:         stateKey,
+	})
+	handler := NewPollingHandler(1, stateKey, portClient, nil)
+
+	assert.False(t, handler.isResyncRequestsPollingEnabled())
+	assert.Nil(t, handler.resyncRequestsPollingEnabled)
+
+	assert.True(t, handler.isResyncRequestsPollingEnabled())
+	require.NotNil(t, handler.resyncRequestsPollingEnabled)
+	assert.True(t, *handler.resyncRequestsPollingEnabled)
+	assert.Equal(t, 2, orgRequestCount)
+}
+
+func TestPollIteration_IntegrationChangeTakesPrecedenceOverResyncRequest(t *testing.T) {
+	stateKey := "test-state-key"
+	initialIntegrationAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	updatedIntegrationAt := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+	resyncRequestAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	mock := &resyncPollingTestServer{
+		t:                      t,
+		stateKey:               stateKey,
+		featureFlags:           []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
+		integrationUpdatedAt:   updatedIntegrationAt,
+		resyncRequestUpdatedAt: &resyncRequestAt,
+	}
+
+	handler, _ := newTestPollingHandler(t, mock)
+	handler.lastIntegrationStateUpdatedAt = formatUpdatedAt(&initialIntegrationAt)
+
+	resyncCalled := false
+	handler.pollIteration(func() {
+		resyncCalled = true
+	})
+
+	require.True(t, resyncCalled)
+	assert.Equal(t, formatUpdatedAt(&updatedIntegrationAt), handler.lastIntegrationStateUpdatedAt)
+	assert.Empty(t, handler.lastResyncRequestUpdatedAt)
+	assert.Equal(t, 0, mock.ResyncRequestCallCount())
+}
+
+func TestPollIteration_ResyncRequestPathUsesPollingQueryParam(t *testing.T) {
+	stateKey := "test-state-key"
+	integrationUpdatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	var integrationQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/v1/auth/access_token":
+			_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
+				AccessToken: "test-token",
+				ExpiresIn:   3600,
+			})
+		case r.URL.Path == "/v1/organization":
+			_ = json.NewEncoder(w).Encode(port.ResponseBody{
+				OK: true,
+				OrgDetails: port.OrgDetails{
+					OrgId:        "test-org",
+					FeatureFlags: []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/v1/integration/"):
+			if strings.HasSuffix(r.URL.Path, "/resync-request") {
+				updatedAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+				_ = json.NewEncoder(w).Encode(struct {
+					OK      bool                                 `json:"ok"`
+					Request *port.IntegrationResyncTriggerRequest `json:"request"`
+				}{
+					OK:      true,
+					Request: &port.IntegrationResyncTriggerRequest{UpdatedAt: &updatedAt},
+				})
+				return
+			}
+			integrationQuery = r.URL.Query().Get("isPolling")
+			_ = json.NewEncoder(w).Encode(port.ResponseBody{
+				OK: true,
+				Integration: port.Integration{
+					UpdatedAt: &integrationUpdatedAt,
+				},
+			})
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	portClient := cli.New(&config.ApplicationConfiguration{
+		PortBaseURL:      server.URL,
+		PortClientId:     "test-client-id",
+		PortClientSecret: "test-client-secret",
+		StateKey:         stateKey,
+	})
+	handler := NewPollingHandler(1, stateKey, portClient, nil)
+	handler.lastIntegrationStateUpdatedAt = formatUpdatedAt(&integrationUpdatedAt)
+
+	handler.pollIteration(func() {})
+
+	assert.Equal(t, "true", integrationQuery)
+}

--- a/pkg/event_handler/polling/polling_state_test.go
+++ b/pkg/event_handler/polling/polling_state_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestShouldResync(t *testing.T) {
-	assert.False(t, shouldResync("2026-01-02T00:00:00Z", ""))
+	assert.True(t, shouldResync("2026-01-02T00:00:00Z", ""))
 	assert.False(t, shouldResync("2026-01-02T00:00:00Z", "2026-01-02T00:00:00Z"))
 	assert.True(t, shouldResync("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z"))
 }

--- a/pkg/event_handler/polling/polling_state_test.go
+++ b/pkg/event_handler/polling/polling_state_test.go
@@ -1,0 +1,31 @@
+package polling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldResync(t *testing.T) {
+	assert.False(t, shouldResync("2026-01-02T00:00:00Z", ""))
+	assert.False(t, shouldResync("2026-01-02T00:00:00Z", "2026-01-02T00:00:00Z"))
+	assert.True(t, shouldResync("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z"))
+}
+
+func TestShouldResyncFromResyncRequest(t *testing.T) {
+	assert.False(t, shouldResyncFromResyncRequest("", ""))
+	assert.False(t, shouldResyncFromResyncRequest("", "2026-01-01T00:00:00Z"))
+	assert.False(t, shouldResyncFromResyncRequest("invalid", ""))
+	assert.True(t, shouldResyncFromResyncRequest("2026-01-02T00:00:00Z", ""))
+	assert.True(t, shouldResyncFromResyncRequest("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z"))
+	assert.False(t, shouldResyncFromResyncRequest("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"))
+	assert.True(t, shouldResyncFromResyncRequest("2026-01-02T00:00:00Z", "invalid"))
+}
+
+func TestFormatUpdatedAt(t *testing.T) {
+	assert.Equal(t, "", formatUpdatedAt(nil))
+
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, "2026-01-01T00:00:00Z", formatUpdatedAt(&ts))
+}

--- a/pkg/port/cli/integration.go
+++ b/pkg/port/cli/integration.go
@@ -42,10 +42,22 @@ func (c *PortClient) CreateIntegration(i *port.Integration, queryParams map[stri
 }
 
 func (c *PortClient) GetIntegration(stateKey string) (*port.Integration, error) {
+	return c.getIntegration(stateKey, nil)
+}
+
+func (c *PortClient) GetIntegrationForPolling(stateKey string) (*port.Integration, error) {
+	return c.getIntegration(stateKey, map[string]string{
+		"isPolling": "true",
+	})
+}
+
+func (c *PortClient) getIntegration(stateKey string, queryParams map[string]string) (*port.Integration, error) {
 	pb := &port.ResponseBody{}
-	resp, err := c.Client.R().
-		SetResult(&pb).
-		Get(fmt.Sprintf("v1/integration/%s", stateKey))
+	req := c.Client.R().SetResult(&pb)
+	if len(queryParams) > 0 {
+		req.SetQueryParams(queryParams)
+	}
+	resp, err := req.Get(fmt.Sprintf("v1/integration/%s", stateKey))
 	if err != nil {
 		return nil, err
 	}
@@ -53,6 +65,25 @@ func (c *PortClient) GetIntegration(stateKey string) (*port.Integration, error) 
 		return nil, fmt.Errorf("failed to get integration, got: %s", resp.Body())
 	}
 	return &pb.Integration, nil
+}
+
+type integrationResyncRequestResponse struct {
+	OK      bool                                 `json:"ok"`
+	Request *port.IntegrationResyncTriggerRequest `json:"request"`
+}
+
+func (c *PortClient) GetIntegrationResyncRequest(stateKey string) (*port.IntegrationResyncTriggerRequest, error) {
+	pb := &integrationResyncRequestResponse{}
+	resp, err := c.Client.R().
+		SetResult(&pb).
+		Get(fmt.Sprintf("v1/integration/%s/resync-request", stateKey))
+	if err != nil {
+		return nil, err
+	}
+	if !pb.OK {
+		return nil, fmt.Errorf("failed to get integration resync request, got: %s", resp.Body())
+	}
+	return pb.Request, nil
 }
 
 func (c *PortClient) DeleteIntegration(stateKey string) error {

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -358,7 +358,12 @@ type IntegrationAppConfig struct {
 
 const (
 	OrgUseProvisionedDefaultsFeatureFlag = "USE_PROVISIONED_DEFAULTS"
+	OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag = "OCEAN_POLLING_INTEGRATION_RESYNC_REQUESTS_ENABLED"
 )
+
+type IntegrationResyncTriggerRequest struct {
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+}
 
 type CreatePortResourcesOrigin string
 


### PR DESCRIPTION
# Description

Polling event listener: when the organization feature flag OCEAN_POLLING_INTEGRATION_RESYNC_REQUESTS_ENABLED (same one like in ocean) is present, k8s-exporter polls the integration resync-request endpoint when the integration document’s updatedAt is unchanged, and runs a resync when the request’s updatedAt is newer than the last stored watermark.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

