### PR TITLE
update kafka event listener to consume from the new topic

### DIFF
--- a/pkg/event_handler/consumer/event_listener.go
+++ b/pkg/event_handler/consumer/event_listener.go
@@ -39,11 +39,15 @@ type IntegrationResyncRequestMessage struct {
 	} `json:"context"`
 }
 
-func resolveKafkaTopic(orgId string, portClient *cli.PortClient) (topic string, useIntegrationResyncTopic bool) {
-	if org_details.ShouldUseIntegrationResyncRequestsTopic(portClient) {
-		return orgId + integrationResyncRequestsTopicSuffix, true
+func resolveKafkaTopic(orgId string, portClient *cli.PortClient) (topic string, useIntegrationResyncTopic bool, err error) {
+	useIntegrationResyncTopic, err = org_details.ShouldUseIntegrationResyncRequestsTopic(portClient)
+	if err != nil {
+		return "", false, err
 	}
-	return orgId + changeLogTopicSuffix, false
+	if useIntegrationResyncTopic {
+		return orgId + integrationResyncRequestsTopicSuffix, true, nil
+	}
+	return orgId + changeLogTopicSuffix, false, nil
 }
 
 func NewEventListener(stateKey string, portClient *cli.PortClient) (*EventListener, error) {
@@ -66,7 +70,10 @@ func NewEventListener(stateKey string, portClient *cli.PortClient) (*EventListen
 		GroupID:                 orgId + ".k8s." + stateKey,
 	}
 
-	topic, useIntegrationResyncTopic := resolveKafkaTopic(orgId, portClient)
+	topic, useIntegrationResyncTopic, err := resolveKafkaTopic(orgId, portClient)
+	if err != nil {
+		return nil, err
+	}
 	instance, err := NewConsumer(c, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/event_handler/consumer/event_listener.go
+++ b/pkg/event_handler/consumer/event_listener.go
@@ -12,11 +12,17 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
+const (
+	changeLogTopicSuffix                 = ".change.log"
+	integrationResyncRequestsTopicSuffix = ".integration.resync.requests"
+)
+
 type EventListener struct {
-	stateKey   string
-	portClient *cli.PortClient
-	topic      string
-	consumer   *Consumer
+	stateKey                    string
+	portClient                  *cli.PortClient
+	topic                       string
+	useIntegrationResyncTopic   bool
+	consumer                    *Consumer
 }
 
 type IncomingMessage struct {
@@ -25,6 +31,19 @@ type IncomingMessage struct {
 			Identifier string `json:"installationId"`
 		} `json:"after"`
 	} `json:"diff"`
+}
+
+type IntegrationResyncRequestMessage struct {
+	Context *struct {
+		IntegrationId string `json:"integrationId"`
+	} `json:"context"`
+}
+
+func resolveKafkaTopic(orgId string, portClient *cli.PortClient) (topic string, useIntegrationResyncTopic bool) {
+	if org_details.ShouldUseIntegrationResyncRequestsTopic(portClient) {
+		return orgId + integrationResyncRequestsTopicSuffix, true
+	}
+	return orgId + changeLogTopicSuffix, false
 }
 
 func NewEventListener(stateKey string, portClient *cli.PortClient) (*EventListener, error) {
@@ -47,38 +66,64 @@ func NewEventListener(stateKey string, portClient *cli.PortClient) (*EventListen
 		GroupID:                 orgId + ".k8s." + stateKey,
 	}
 
-	topic := orgId + ".change.log"
+	topic, useIntegrationResyncTopic := resolveKafkaTopic(orgId, portClient)
 	instance, err := NewConsumer(c, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return &EventListener{
-		stateKey:   stateKey,
-		portClient: portClient,
-		topic:      topic,
-		consumer:   instance,
+		stateKey:                  stateKey,
+		portClient:                portClient,
+		topic:                     topic,
+		useIntegrationResyncTopic: useIntegrationResyncTopic,
+		consumer:                  instance,
 	}, nil
 }
 
-func shouldResync(stateKey string, message *IncomingMessage) bool {
+func shouldResyncFromChangeLog(stateKey string, message *IncomingMessage) bool {
 	return message.Diff != nil &&
 		message.Diff.After != nil &&
 		message.Diff.After.Identifier != "" &&
 		message.Diff.After.Identifier == stateKey
 }
 
+func shouldResyncFromIntegrationResyncRequest(stateKey string, message *IntegrationResyncRequestMessage) bool {
+	return message.Context != nil &&
+		message.Context.IntegrationId != "" &&
+		message.Context.IntegrationId == stateKey
+}
+
 func (l *EventListener) Run(resync func()) error {
 	logger.Info("Starting Kafka event listener")
 
+	if l.useIntegrationResyncTopic {
+		logger.Info("Starting Kafka consumer for integration resync requests topic")
+	} else {
+		logger.Info("Starting Kafka consumer for change log topic")
+	}
+
 	logger.Infow("Starting consumer for topic", "topic", l.topic)
 	l.consumer.Consume(l.topic, func(value []byte) {
+		if l.useIntegrationResyncTopic {
+			incomingMessage := &IntegrationResyncRequestMessage{}
+			parsingError := json.Unmarshal(value, &incomingMessage)
+			if parsingError != nil {
+				logger.Errorw("error handling message", "error", parsingError.Error())
+				utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))
+			} else if shouldResyncFromIntegrationResyncRequest(l.stateKey, incomingMessage) {
+				logger.Info("Changes detected. Resyncing...")
+				resync()
+			}
+			return
+		}
+
 		incomingMessage := &IncomingMessage{}
 		parsingError := json.Unmarshal(value, &incomingMessage)
 		if parsingError != nil {
 			logger.Errorw("error handling message", "error", parsingError.Error())
 			utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))
-		} else if shouldResync(l.stateKey, incomingMessage) {
+		} else if shouldResyncFromChangeLog(l.stateKey, incomingMessage) {
 			logger.Info("Changes detected. Resyncing...")
 			resync()
 		}

--- a/pkg/event_handler/consumer/event_listener.go
+++ b/pkg/event_handler/consumer/event_listener.go
@@ -26,11 +26,15 @@ type EventListener struct {
 }
 
 type IncomingMessage struct {
+	Action  string `json:"action,omitempty"`
+	Context *struct {
+		IntegrationId string `json:"integrationId"`
+	} `json:"context,omitempty"`
 	Diff *struct {
 		After *struct {
 			Identifier string `json:"installationId"`
 		} `json:"after"`
-	} `json:"diff"`
+	} `json:"diff,omitempty"`
 }
 
 type IntegrationResyncRequestMessage struct {
@@ -89,10 +93,23 @@ func NewEventListener(stateKey string, portClient *cli.PortClient) (*EventListen
 }
 
 func shouldResyncFromChangeLog(stateKey string, message *IncomingMessage) bool {
+	if message == nil {
+		return false
+	}
+	if shouldResyncRequestFromChangeLog(stateKey, message) {
+		return true
+	}
 	return message.Diff != nil &&
 		message.Diff.After != nil &&
 		message.Diff.After.Identifier != "" &&
 		message.Diff.After.Identifier == stateKey
+}
+
+func shouldResyncRequestFromChangeLog(stateKey string, message *IncomingMessage) bool {
+	return message.Action == "RESYNC" &&
+		message.Context != nil &&
+		message.Context.IntegrationId != "" &&
+		message.Context.IntegrationId == stateKey
 }
 
 func shouldResyncFromIntegrationResyncRequest(stateKey string, message *IntegrationResyncRequestMessage) bool {

--- a/pkg/event_handler/consumer/event_listener.go
+++ b/pkg/event_handler/consumer/event_listener.go
@@ -114,7 +114,7 @@ func (l *EventListener) Run(resync func()) error {
 	l.consumer.Consume(l.topic, func(value []byte) {
 		if l.useIntegrationResyncTopic {
 			incomingMessage := &IntegrationResyncRequestMessage{}
-			parsingError := json.Unmarshal(value, &incomingMessage)
+			parsingError := json.Unmarshal(value, incomingMessage)
 			if parsingError != nil {
 				logger.Errorw("error handling message", "error", parsingError.Error())
 				utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))
@@ -126,7 +126,7 @@ func (l *EventListener) Run(resync func()) error {
 		}
 
 		incomingMessage := &IncomingMessage{}
-		parsingError := json.Unmarshal(value, &incomingMessage)
+		parsingError := json.Unmarshal(value, incomingMessage)
 		if parsingError != nil {
 			logger.Errorw("error handling message", "error", parsingError.Error())
 			utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))

--- a/pkg/event_handler/consumer/event_listener.go
+++ b/pkg/event_handler/consumer/event_listener.go
@@ -118,6 +118,43 @@ func shouldResyncFromIntegrationResyncRequest(stateKey string, message *Integrat
 		message.Context.IntegrationId == stateKey
 }
 
+func logAndReportMessageParseError(err error) {
+	logger.Errorw("error handling message", "error", err.Error())
+	utilruntime.HandleError(fmt.Errorf("error handling message: %s", err.Error()))
+}
+
+func (l *EventListener) handleIntegrationResyncMessage(value []byte, resync func()) {
+	incomingMessage := &IntegrationResyncRequestMessage{}
+	if err := json.Unmarshal(value, incomingMessage); err != nil {
+		logAndReportMessageParseError(err)
+		return
+	}
+	if shouldResyncFromIntegrationResyncRequest(l.stateKey, incomingMessage) {
+		logger.Info("Changes detected. Resyncing...")
+		resync()
+	}
+}
+
+func (l *EventListener) handleChangeLogMessage(value []byte, resync func()) {
+	incomingMessage := &IncomingMessage{}
+	if err := json.Unmarshal(value, incomingMessage); err != nil {
+		logAndReportMessageParseError(err)
+		return
+	}
+	if shouldResyncFromChangeLog(l.stateKey, incomingMessage) {
+		logger.Info("Changes detected. Resyncing...")
+		resync()
+	}
+}
+
+func (l *EventListener) handleMessage(value []byte, resync func()) {
+	if l.useIntegrationResyncTopic {
+		l.handleIntegrationResyncMessage(value, resync)
+		return
+	}
+	l.handleChangeLogMessage(value, resync)
+}
+
 func (l *EventListener) Run(resync func()) error {
 	logger.Info("Starting Kafka event listener")
 
@@ -129,28 +166,7 @@ func (l *EventListener) Run(resync func()) error {
 
 	logger.Infow("Starting consumer for topic", "topic", l.topic)
 	l.consumer.Consume(l.topic, func(value []byte) {
-		if l.useIntegrationResyncTopic {
-			incomingMessage := &IntegrationResyncRequestMessage{}
-			parsingError := json.Unmarshal(value, incomingMessage)
-			if parsingError != nil {
-				logger.Errorw("error handling message", "error", parsingError.Error())
-				utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))
-			} else if shouldResyncFromIntegrationResyncRequest(l.stateKey, incomingMessage) {
-				logger.Info("Changes detected. Resyncing...")
-				resync()
-			}
-			return
-		}
-
-		incomingMessage := &IncomingMessage{}
-		parsingError := json.Unmarshal(value, incomingMessage)
-		if parsingError != nil {
-			logger.Errorw("error handling message", "error", parsingError.Error())
-			utilruntime.HandleError(fmt.Errorf("error handling message: %s", parsingError.Error()))
-		} else if shouldResyncFromChangeLog(l.stateKey, incomingMessage) {
-			logger.Info("Changes detected. Resyncing...")
-			resync()
-		}
+		l.handleMessage(value, resync)
 	}, nil)
 
 	return nil

--- a/pkg/event_handler/consumer/event_listener_test.go
+++ b/pkg/event_handler/consumer/event_listener_test.go
@@ -1,0 +1,59 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldResyncFromChangeLog(t *testing.T) {
+	stateKey := "integration-1"
+
+	assert.True(t, shouldResyncFromChangeLog(stateKey, &IncomingMessage{
+		Diff: &struct {
+			After *struct {
+				Identifier string `json:"installationId"`
+			} `json:"after"`
+		}{
+			After: &struct {
+				Identifier string `json:"installationId"`
+			}{
+				Identifier: stateKey,
+			},
+		},
+	}))
+	assert.False(t, shouldResyncFromChangeLog(stateKey, &IncomingMessage{
+		Diff: &struct {
+			After *struct {
+				Identifier string `json:"installationId"`
+			} `json:"after"`
+		}{
+			After: &struct {
+				Identifier string `json:"installationId"`
+			}{
+				Identifier: "integration-2",
+			},
+		},
+	}))
+	assert.False(t, shouldResyncFromChangeLog(stateKey, &IncomingMessage{}))
+}
+
+func TestShouldResyncFromIntegrationResyncRequest(t *testing.T) {
+	stateKey := "integration-1"
+
+	assert.True(t, shouldResyncFromIntegrationResyncRequest(stateKey, &IntegrationResyncRequestMessage{
+		Context: &struct {
+			IntegrationId string `json:"integrationId"`
+		}{
+			IntegrationId: stateKey,
+		},
+	}))
+	assert.False(t, shouldResyncFromIntegrationResyncRequest(stateKey, &IntegrationResyncRequestMessage{
+		Context: &struct {
+			IntegrationId string `json:"integrationId"`
+		}{
+			IntegrationId: "integration-2",
+		},
+	}))
+	assert.False(t, shouldResyncFromIntegrationResyncRequest(stateKey, &IntegrationResyncRequestMessage{}))
+}

--- a/pkg/event_handler/consumer/event_listener_test.go
+++ b/pkg/event_handler/consumer/event_listener_test.go
@@ -40,6 +40,64 @@ func TestShouldResyncFromChangeLog(t *testing.T) {
 	assert.False(t, shouldResyncFromChangeLog(stateKey, &IncomingMessage{}))
 }
 
+func TestShouldResyncRequestFromChangeLog(t *testing.T) {
+	stateKey := "integration-1"
+
+	assert.True(t, shouldResyncRequestFromChangeLog(stateKey, &IncomingMessage{
+		Action: "RESYNC",
+		Context: &struct {
+			IntegrationId string `json:"integrationId"`
+		}{
+			IntegrationId: stateKey,
+		},
+	}))
+	assert.False(t, shouldResyncRequestFromChangeLog(stateKey, &IncomingMessage{
+		Action: "RESYNC",
+		Context: &struct {
+			IntegrationId string `json:"integrationId"`
+		}{
+			IntegrationId: "integration-2",
+		},
+	}))
+	assert.False(t, shouldResyncRequestFromChangeLog(stateKey, &IncomingMessage{
+		Action: "UPDATE",
+		Context: &struct {
+			IntegrationId string `json:"integrationId"`
+		}{
+			IntegrationId: stateKey,
+		},
+	}))
+}
+
+func changeLogTriggersResync(stateKey string, value []byte) (bool, error) {
+	incomingMessage := &IncomingMessage{}
+	if err := json.Unmarshal(value, incomingMessage); err != nil {
+		return false, err
+	}
+	return shouldResyncFromChangeLog(stateKey, incomingMessage), nil
+}
+
+func TestIncomingMessage_UnmarshalTriggersResyncForMatchingStateKey(t *testing.T) {
+	stateKey := "integration-1"
+
+	resyncPayload := []byte(`{
+		"action": "RESYNC",
+		"context": { "integrationId": "integration-1" }
+	}`)
+	triggersResync, err := changeLogTriggersResync(stateKey, resyncPayload)
+	require.NoError(t, err)
+	assert.True(t, triggersResync, "RESYNC on change.log with matching context.integrationId should trigger resync")
+
+	changeLogPayload := []byte(`{"diff":{"after":{"installationId":"integration-1"}}}`)
+	triggersResync, err = changeLogTriggersResync(stateKey, changeLogPayload)
+	require.NoError(t, err)
+	assert.True(t, triggersResync, "legacy change.log payload should trigger resync")
+
+	triggersResync, err = changeLogTriggersResync(stateKey, []byte("null"))
+	require.NoError(t, err)
+	assert.False(t, triggersResync, "top-level JSON null must not panic and must not trigger resync")
+}
+
 func TestShouldResyncFromIntegrationResyncRequest(t *testing.T) {
 	stateKey := "integration-1"
 

--- a/pkg/event_handler/consumer/event_listener_test.go
+++ b/pkg/event_handler/consumer/event_listener_test.go
@@ -94,4 +94,8 @@ func TestIntegrationResyncRequestMessage_UnmarshalTriggersResyncForMatchingState
 	triggersResync, err = integrationResyncRequestTriggersResync(stateKey, wrongJSONKeyPayload)
 	require.NoError(t, err)
 	assert.False(t, triggersResync, "wrong JSON field name must not populate integrationId")
+
+	triggersResync, err = integrationResyncRequestTriggersResync(stateKey, []byte("null"))
+	require.NoError(t, err)
+	assert.False(t, triggersResync, "top-level JSON null must not panic and must not trigger resync")
 }

--- a/pkg/event_handler/consumer/event_listener_test.go
+++ b/pkg/event_handler/consumer/event_listener_test.go
@@ -1,9 +1,11 @@
 package consumer
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldResyncFromChangeLog(t *testing.T) {
@@ -56,4 +58,40 @@ func TestShouldResyncFromIntegrationResyncRequest(t *testing.T) {
 		},
 	}))
 	assert.False(t, shouldResyncFromIntegrationResyncRequest(stateKey, &IntegrationResyncRequestMessage{}))
+}
+
+// integrationResyncRequestTriggersResync mirrors the unmarshal + filter path in EventListener.Run.
+func integrationResyncRequestTriggersResync(stateKey string, value []byte) (bool, error) {
+	incomingMessage := &IntegrationResyncRequestMessage{}
+	if err := json.Unmarshal(value, incomingMessage); err != nil {
+		return false, err
+	}
+	return shouldResyncFromIntegrationResyncRequest(stateKey, incomingMessage), nil
+}
+
+func TestIntegrationResyncRequestMessage_UnmarshalTriggersResyncForMatchingStateKey(t *testing.T) {
+	stateKey := "integration-1"
+
+	// Representative payload from the integration resync requests topic (extra fields are ignored).
+	payload := []byte(`{
+		"context": {
+			"integrationId": "integration-1",
+			"orgId": "org-abc"
+		},
+		"requestId": "req-123"
+	}`)
+
+	triggersResync, err := integrationResyncRequestTriggersResync(stateKey, payload)
+	require.NoError(t, err)
+	assert.True(t, triggersResync, "matching integrationId in wire JSON should trigger resync")
+
+	otherIntegrationPayload := []byte(`{"context":{"integrationId":"integration-2"}}`)
+	triggersResync, err = integrationResyncRequestTriggersResync(stateKey, otherIntegrationPayload)
+	require.NoError(t, err)
+	assert.False(t, triggersResync, "non-matching integrationId should not trigger resync")
+
+	wrongJSONKeyPayload := []byte(`{"context":{"integration_id":"integration-1"}}`)
+	triggersResync, err = integrationResyncRequestTriggersResync(stateKey, wrongJSONKeyPayload)
+	require.NoError(t, err)
+	assert.False(t, triggersResync, "wrong JSON field name must not populate integrationId")
 }

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -357,7 +357,8 @@ type IntegrationAppConfig struct {
 }
 
 const (
-	OrgUseProvisionedDefaultsFeatureFlag = "USE_PROVISIONED_DEFAULTS"
+	OrgUseProvisionedDefaultsFeatureFlag                     = "USE_PROVISIONED_DEFAULTS"
+	OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag = "OCEAN_KAFKA_INTEGRATION_RESYNC_REQUESTS_TOPIC_ENABLED"
 )
 
 type CreatePortResourcesOrigin string

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -26,6 +26,7 @@ func GetOrganizationFeatureFlags(portClient *cli.PortClient) ([]string, error) {
 }
 
 func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) (bool, error) {
+	return false, nil
 	flags, err := GetOrganizationFeatureFlags(portClient)
 	if err != nil {
 		return false, err

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -3,6 +3,8 @@ package org_details
 import (
 	"fmt"
 
+	"github.com/port-labs/port-k8s-exporter/pkg/logger"
+	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
 )
 
@@ -22,4 +24,23 @@ func GetOrganizationFeatureFlags(portClient *cli.PortClient) ([]string, error) {
 	}
 
 	return flags, nil
+}
+
+func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) bool {
+	flags, err := GetOrganizationFeatureFlags(portClient)
+	if err != nil {
+		logger.Warnw(
+			"Failed to fetch organization feature flags. Falling back to legacy change log topic consumer",
+			"error", err.Error(),
+		)
+		return false
+	}
+
+	for _, flag := range flags {
+		if flag == port.OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -3,7 +3,6 @@ package org_details
 import (
 	"fmt"
 
-	"github.com/port-labs/port-k8s-exporter/pkg/logger"
 	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
 )
@@ -26,21 +25,17 @@ func GetOrganizationFeatureFlags(portClient *cli.PortClient) ([]string, error) {
 	return flags, nil
 }
 
-func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) bool {
+func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) (bool, error) {
 	flags, err := GetOrganizationFeatureFlags(portClient)
 	if err != nil {
-		logger.Warnw(
-			"Failed to fetch organization feature flags. Falling back to legacy change log topic consumer",
-			"error", err.Error(),
-		)
-		return false
+		return false, err
 	}
 
 	for _, flag := range flags {
 		if flag == port.OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -26,7 +26,6 @@ func GetOrganizationFeatureFlags(portClient *cli.PortClient) ([]string, error) {
 }
 
 func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) (bool, error) {
-	return false, nil
 	flags, err := GetOrganizationFeatureFlags(portClient)
 	if err != nil {
 		return false, err

--- a/pkg/port/org_details/org_details.go
+++ b/pkg/port/org_details/org_details.go
@@ -2,6 +2,7 @@ package org_details
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
@@ -31,11 +32,5 @@ func ShouldUseIntegrationResyncRequestsTopic(portClient *cli.PortClient) (bool, 
 		return false, err
 	}
 
-	for _, flag := range flags {
-		if flag == port.OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return slices.Contains(flags, port.OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag), nil
 }


### PR DESCRIPTION
# Description
This PR updates the Kafka event listener to support consuming resync requests from a new organization-scoped Kafka topic when the corresponding Port feature flag is enabled.
## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

