### PR TITLE
Fix/polling resync request watermark

### DIFF
--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -130,6 +130,24 @@ func (h *Handler) isResyncRequestsPollingEnabled() bool {
 	return enabled
 }
 
+func (h *Handler) initializeResyncRequestWatermark() {
+	if !h.isResyncRequestsPollingEnabled() {
+		return
+	}
+
+	resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
+	if err != nil {
+		logger.Errorw(
+			"Failed to fetch integration resync request while initializing polling watermark",
+			"error", err.Error(),
+		)
+		return
+	}
+	if resyncRequest != nil {
+		h.lastResyncRequestUpdatedAt = formatUpdatedAt(resyncRequest.UpdatedAt)
+	}
+}
+
 func (h *Handler) pollIteration(resync func()) {
 	logger.Infof("Polling event listener iteration after %d seconds. Checking for changes...", h.pollingRate)
 
@@ -143,11 +161,12 @@ func (h *Handler) pollIteration(resync func()) {
 	}
 
 	lastUpdatedAt := formatUpdatedAt(integration.UpdatedAt)
-	shouldTriggerResync := shouldResync(lastUpdatedAt, h.lastIntegrationStateUpdatedAt)
+	integrationChanged := shouldResync(lastUpdatedAt, h.lastIntegrationStateUpdatedAt)
 	resyncReason := "Detected change in integration, resyncing"
 	resyncRequestUpdatedAt := ""
+	resyncRequestChanged := false
 
-	if !shouldTriggerResync && h.isResyncRequestsPollingEnabled() {
+	if h.isResyncRequestsPollingEnabled() {
 		resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
 		if err != nil {
 			logger.Errorw(
@@ -156,17 +175,17 @@ func (h *Handler) pollIteration(resync func()) {
 			)
 		} else if resyncRequest != nil {
 			resyncRequestUpdatedAt = formatUpdatedAt(resyncRequest.UpdatedAt)
-			shouldTriggerResync = shouldResyncFromResyncRequest(
+			resyncRequestChanged = shouldResyncFromResyncRequest(
 				resyncRequestUpdatedAt,
 				h.lastResyncRequestUpdatedAt,
 			)
-			if shouldTriggerResync {
+			if resyncRequestChanged && !integrationChanged {
 				resyncReason = "Detected integration resync request"
 			}
 		}
 	}
 
-	if !shouldTriggerResync {
+	if !integrationChanged && !resyncRequestChanged {
 		return
 	}
 
@@ -186,6 +205,7 @@ func (h *Handler) Run(resync func()) {
 		logger.Errorf("Error fetching the first integration state: %s", err.Error())
 	} else {
 		h.lastIntegrationStateUpdatedAt = formatUpdatedAt(integration.UpdatedAt)
+		h.initializeResyncRequestWatermark()
 	}
 
 	sigChan := make(chan os.Signal, 1)

--- a/pkg/event_handler/polling/polling_resync_request_test.go
+++ b/pkg/event_handler/polling/polling_resync_request_test.go
@@ -313,8 +313,39 @@ func TestPollIteration_IntegrationChangeTakesPrecedenceOverResyncRequest(t *test
 
 	require.True(t, resyncCalled)
 	assert.Equal(t, formatUpdatedAt(&updatedIntegrationAt), handler.lastIntegrationStateUpdatedAt)
-	assert.Empty(t, handler.lastResyncRequestUpdatedAt)
-	assert.Equal(t, 0, mock.ResyncRequestCallCount())
+	assert.Equal(t, formatUpdatedAt(&resyncRequestAt), handler.lastResyncRequestUpdatedAt)
+	assert.Equal(t, 1, mock.ResyncRequestCallCount())
+}
+
+func TestPollIteration_IntegrationResyncDoesNotRetriggerStaleResyncRequest(t *testing.T) {
+	stateKey := "test-state-key"
+	initialIntegrationAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	updatedIntegrationAt := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+	resyncRequestAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	mock := &resyncPollingTestServer{
+		t:                      t,
+		stateKey:               stateKey,
+		featureFlags:           []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
+		integrationUpdatedAt:   updatedIntegrationAt,
+		resyncRequestUpdatedAt: &resyncRequestAt,
+	}
+
+	handler, _ := newTestPollingHandler(t, mock)
+	handler.lastIntegrationStateUpdatedAt = formatUpdatedAt(&initialIntegrationAt)
+
+	firstResyncCalled := false
+	handler.pollIteration(func() {
+		firstResyncCalled = true
+	})
+	require.True(t, firstResyncCalled)
+	assert.Equal(t, formatUpdatedAt(&resyncRequestAt), handler.lastResyncRequestUpdatedAt)
+
+	secondResyncCalled := false
+	handler.pollIteration(func() {
+		secondResyncCalled = true
+	})
+	assert.False(t, secondResyncCalled, "stale resync request should not trigger another resync after integration resync advanced the watermark")
 }
 
 func TestPollIteration_ResyncRequestPathUsesPollingQueryParam(t *testing.T) {

--- a/pkg/port/cli/integration.go
+++ b/pkg/port/cli/integration.go
@@ -42,7 +42,9 @@ func (c *PortClient) CreateIntegration(i *port.Integration, queryParams map[stri
 }
 
 func (c *PortClient) GetIntegration(stateKey string) (*port.Integration, error) {
-	return c.getIntegration(stateKey, nil)
+	return c.getIntegration(stateKey, map[string]string{
+		"isPolling": "false",
+	})
 }
 
 func (c *PortClient) GetIntegrationForPolling(stateKey string) (*port.Integration, error) {


### PR DESCRIPTION
# Description

Fixes duplicate resyncs in the polling event listener when a resync request already exists in Port.

Resync-request watermark bug: When a resync was triggered by an integration change, we skipped fetching the resync request, so lastResyncRequestUpdatedAt stayed empty. On the next poll, any existing resync request was treated as new and triggered another resync. We now always fetch the resync request when the feature flag is enabled, advance the watermark on any resync (including integration-driven), and initialize the watermark on handler startup.

isPolling query param: Non-polling GetIntegration calls now send isPolling=false explicitly; polling continues to use GetIntegrationForPolling with isPolling=true.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

