### PR TITLE
remove Polling FF

### DIFF
--- a/pkg/event_handler/polling/polling.go
+++ b/pkg/event_handler/polling/polling.go
@@ -4,14 +4,11 @@ import (
 	"errors"
 	"os"
 	"os/signal"
-	"slices"
 	"syscall"
 	"time"
 
 	"github.com/port-labs/port-k8s-exporter/pkg/logger"
-	"github.com/port-labs/port-k8s-exporter/pkg/port"
 	"github.com/port-labs/port-k8s-exporter/pkg/port/cli"
-	"github.com/port-labs/port-k8s-exporter/pkg/port/org_details"
 )
 
 type ITicker interface {
@@ -41,9 +38,8 @@ type Handler struct {
 	stateKey                         string
 	portClient                       *cli.PortClient
 	pollingRate                      uint
-	lastIntegrationStateUpdatedAt    string
-	lastResyncRequestUpdatedAt       string
-	resyncRequestsPollingEnabled     *bool
+	lastIntegrationStateUpdatedAt string
+	lastResyncRequestUpdatedAt    string
 }
 
 func NewPollingHandler(pollingRate uint, stateKey string, portClient *cli.PortClient, tickerOverride ITicker) *Handler {
@@ -111,30 +107,7 @@ func parsePortTimestamp(value string) (time.Time, error) {
 	return time.Time{}, errors.New("invalid timestamp format")
 }
 
-func (h *Handler) isResyncRequestsPollingEnabled() bool {
-	if h.resyncRequestsPollingEnabled != nil {
-		return *h.resyncRequestsPollingEnabled
-	}
-
-	flags, err := org_details.GetOrganizationFeatureFlags(h.portClient)
-	if err != nil {
-		logger.Errorw(
-			"Failed to fetch organization feature flags for resync request polling, skipping resync request polling for this iteration",
-			"error", err.Error(),
-		)
-		return false
-	}
-
-	enabled := slices.Contains(flags, port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag)
-	h.resyncRequestsPollingEnabled = &enabled
-	return enabled
-}
-
 func (h *Handler) initializeResyncRequestWatermark() {
-	if !h.isResyncRequestsPollingEnabled() {
-		return
-	}
-
 	resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
 	if err != nil {
 		logger.Errorw(
@@ -166,22 +139,20 @@ func (h *Handler) pollIteration(resync func()) {
 	resyncRequestUpdatedAt := ""
 	resyncRequestChanged := false
 
-	if h.isResyncRequestsPollingEnabled() {
-		resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
-		if err != nil {
-			logger.Errorw(
-				"Failed to fetch integration resync request in polling listener, continuing without resync request signal",
-				"error", err.Error(),
-			)
-		} else if resyncRequest != nil {
-			resyncRequestUpdatedAt = formatUpdatedAt(resyncRequest.UpdatedAt)
-			resyncRequestChanged = shouldResyncFromResyncRequest(
-				resyncRequestUpdatedAt,
-				h.lastResyncRequestUpdatedAt,
-			)
-			if resyncRequestChanged && !integrationChanged {
-				resyncReason = "Detected integration resync request"
-			}
+	resyncRequest, err := h.portClient.GetIntegrationResyncRequest(h.stateKey)
+	if err != nil {
+		logger.Errorw(
+			"Failed to fetch integration resync request in polling listener, continuing without resync request signal",
+			"error", err.Error(),
+		)
+	} else if resyncRequest != nil {
+		resyncRequestUpdatedAt = formatUpdatedAt(resyncRequest.UpdatedAt)
+		resyncRequestChanged = shouldResyncFromResyncRequest(
+			resyncRequestUpdatedAt,
+			h.lastResyncRequestUpdatedAt,
+		)
+		if resyncRequestChanged && !integrationChanged {
+			resyncReason = "Detected integration resync request"
 		}
 	}
 

--- a/pkg/event_handler/polling/polling_resync_request_test.go
+++ b/pkg/event_handler/polling/polling_resync_request_test.go
@@ -17,10 +17,9 @@ import (
 )
 
 type resyncPollingTestServer struct {
-	t                    *testing.T
-	stateKey             string
-	featureFlags         []string
-	integrationUpdatedAt time.Time
+	t                      *testing.T
+	stateKey               string
+	integrationUpdatedAt   time.Time
 	resyncRequestUpdatedAt *time.Time
 
 	mu                     sync.Mutex
@@ -40,14 +39,6 @@ func (s *resyncPollingTestServer) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
 			AccessToken: "test-token",
 			ExpiresIn:   3600,
-		})
-	case r.URL.Path == "/v1/organization":
-		_ = json.NewEncoder(w).Encode(port.ResponseBody{
-			OK: true,
-			OrgDetails: port.OrgDetails{
-				OrgId:        "test-org",
-				FeatureFlags: s.featureFlags,
-			},
 		})
 	case r.URL.Path == "/v1/integration/"+s.stateKey:
 		_ = json.NewEncoder(w).Encode(port.ResponseBody{
@@ -107,60 +98,34 @@ func TestPollIteration_ResyncRequestPolling(t *testing.T) {
 	stateKey := "test-state-key"
 
 	tests := []struct {
-		name                         string
-		featureFlags                 []string
-		resyncRequestUpdatedAt       *time.Time
-		lastResyncRequestWatermark   string
-		expectResync                 bool
-		expectResyncRequestFetched   bool
+		name                       string
+		resyncRequestUpdatedAt     *time.Time
+		lastResyncRequestWatermark string
+		expectResync               bool
 	}{
 		{
-			name:                       "feature flag disabled skips resync request polling",
-			featureFlags:               []string{},
-			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
-			lastResyncRequestWatermark: "",
-			expectResync:               false,
-			expectResyncRequestFetched: false,
-		},
-		{
-			name: "feature flag enabled triggers resync when resync request advances",
-			featureFlags: []string{
-				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
-			},
+			name:                       "triggers resync when resync request advances",
 			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
 			lastResyncRequestWatermark: "",
 			expectResync:               true,
-			expectResyncRequestFetched: true,
 		},
 		{
-			name: "feature flag enabled does not resync when watermark matches resync request",
-			featureFlags: []string{
-				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
-			},
+			name:                       "does not resync when watermark matches resync request",
 			resyncRequestUpdatedAt:     &resyncRequestUpdatedAt,
 			lastResyncRequestWatermark: formatUpdatedAt(&resyncRequestUpdatedAt),
 			expectResync:               false,
-			expectResyncRequestFetched: true,
 		},
 		{
-			name: "feature flag enabled does not resync when resync request is older than watermark",
-			featureFlags: []string{
-				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
-			},
+			name:                       "does not resync when resync request is older than watermark",
 			resyncRequestUpdatedAt:     &olderResyncRequestUpdatedAt,
 			lastResyncRequestWatermark: formatUpdatedAt(&resyncRequestUpdatedAt),
 			expectResync:               false,
-			expectResyncRequestFetched: true,
 		},
 		{
-			name: "feature flag enabled does not resync when resync request is missing",
-			featureFlags: []string{
-				port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
-			},
+			name:                       "does not resync when resync request is missing",
 			resyncRequestUpdatedAt:     nil,
 			lastResyncRequestWatermark: "",
 			expectResync:               false,
-			expectResyncRequestFetched: true,
 		},
 	}
 
@@ -169,7 +134,6 @@ func TestPollIteration_ResyncRequestPolling(t *testing.T) {
 			mock := newResyncPollingTestServer(t, resyncPollingTestServer{
 				t:                      t,
 				stateKey:               stateKey,
-				featureFlags:           tt.featureFlags,
 				integrationUpdatedAt:   integrationUpdatedAt,
 				resyncRequestUpdatedAt: tt.resyncRequestUpdatedAt,
 			})
@@ -184,7 +148,7 @@ func TestPollIteration_ResyncRequestPolling(t *testing.T) {
 			})
 
 			assert.Equal(t, tt.expectResync, resyncCalled)
-			assert.Equal(t, tt.expectResyncRequestFetched, mock.ResyncRequestCallCount() > 0)
+			assert.Positive(t, mock.ResyncRequestCallCount())
 
 			if tt.expectResync {
 				assert.Equal(t, formatUpdatedAt(tt.resyncRequestUpdatedAt), handler.lastResyncRequestUpdatedAt)
@@ -202,10 +166,9 @@ func TestPollIteration_ResyncRequestWatermarkAdvancesAcrossIterations(t *testing
 	secondResyncRequestAt := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
 
 	mock := &resyncPollingTestServer{
-		t:                    t,
-		stateKey:             stateKey,
-		featureFlags:         []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
-		integrationUpdatedAt: integrationUpdatedAt,
+		t:                      t,
+		stateKey:               stateKey,
+		integrationUpdatedAt:   integrationUpdatedAt,
 		resyncRequestUpdatedAt: &firstResyncRequestAt,
 	}
 
@@ -237,58 +200,6 @@ func TestPollIteration_ResyncRequestWatermarkAdvancesAcrossIterations(t *testing
 	assert.Equal(t, formatUpdatedAt(&secondResyncRequestAt), handler.lastResyncRequestUpdatedAt)
 }
 
-func TestIsResyncRequestsPollingEnabled_CachesOnlyOnSuccess(t *testing.T) {
-	stateKey := "test-state-key"
-	orgRequestCount := 0
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch {
-		case r.URL.Path == "/v1/auth/access_token":
-			_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
-				AccessToken: "test-token",
-				ExpiresIn:   3600,
-			})
-		case r.URL.Path == "/v1/organization":
-			orgRequestCount++
-			if orgRequestCount == 1 {
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(`{"ok": false}`))
-				return
-			}
-			_ = json.NewEncoder(w).Encode(port.ResponseBody{
-				OK: true,
-				OrgDetails: port.OrgDetails{
-					OrgId: "test-org",
-					FeatureFlags: []string{
-						port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag,
-					},
-				},
-			})
-		default:
-			t.Fatalf("unexpected request: %s", r.URL.Path)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	portClient := cli.New(&config.ApplicationConfiguration{
-		PortBaseURL:      server.URL,
-		PortClientId:     "test-client-id",
-		PortClientSecret: "test-client-secret",
-		StateKey:         stateKey,
-	})
-	handler := NewPollingHandler(1, stateKey, portClient, nil)
-
-	assert.False(t, handler.isResyncRequestsPollingEnabled())
-	assert.Nil(t, handler.resyncRequestsPollingEnabled)
-
-	assert.True(t, handler.isResyncRequestsPollingEnabled())
-	require.NotNil(t, handler.resyncRequestsPollingEnabled)
-	assert.True(t, *handler.resyncRequestsPollingEnabled)
-	assert.Equal(t, 2, orgRequestCount)
-}
-
 func TestPollIteration_IntegrationChangeTakesPrecedenceOverResyncRequest(t *testing.T) {
 	stateKey := "test-state-key"
 	initialIntegrationAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -298,7 +209,6 @@ func TestPollIteration_IntegrationChangeTakesPrecedenceOverResyncRequest(t *test
 	mock := &resyncPollingTestServer{
 		t:                      t,
 		stateKey:               stateKey,
-		featureFlags:           []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
 		integrationUpdatedAt:   updatedIntegrationAt,
 		resyncRequestUpdatedAt: &resyncRequestAt,
 	}
@@ -326,7 +236,6 @@ func TestPollIteration_IntegrationResyncDoesNotRetriggerStaleResyncRequest(t *te
 	mock := &resyncPollingTestServer{
 		t:                      t,
 		stateKey:               stateKey,
-		featureFlags:           []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
 		integrationUpdatedAt:   updatedIntegrationAt,
 		resyncRequestUpdatedAt: &resyncRequestAt,
 	}
@@ -361,14 +270,6 @@ func TestPollIteration_ResyncRequestPathUsesPollingQueryParam(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(port.AccessTokenResponse{
 				AccessToken: "test-token",
 				ExpiresIn:   3600,
-			})
-		case r.URL.Path == "/v1/organization":
-			_ = json.NewEncoder(w).Encode(port.ResponseBody{
-				OK: true,
-				OrgDetails: port.OrgDetails{
-					OrgId:        "test-org",
-					FeatureFlags: []string{port.OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag},
-				},
 			})
 		case strings.HasPrefix(r.URL.Path, "/v1/integration/"):
 			if strings.HasSuffix(r.URL.Path, "/resync-request") {

--- a/pkg/port/models.go
+++ b/pkg/port/models.go
@@ -359,7 +359,6 @@ type IntegrationAppConfig struct {
 const (
 	OrgUseProvisionedDefaultsFeatureFlag                     = "USE_PROVISIONED_DEFAULTS"
 	OrgKafkaIntegrationResyncRequestsTopicEnabledFeatureFlag = "OCEAN_KAFKA_INTEGRATION_RESYNC_REQUESTS_TOPIC_ENABLED"
-	OrgOceanPollingIntegrationResyncRequestsEnabledFeatureFlag = "OCEAN_POLLING_INTEGRATION_RESYNC_REQUESTS_ENABLED"
 )
 
 type IntegrationResyncTriggerRequest struct {


### PR DESCRIPTION
# Description
Removes the OCEAN_POLLING_INTEGRATION_RESYNC_REQUESTS_ENABLED organization feature flag and makes manual resync detection the default for polling integrations. When integration updatedAt is unchanged, the polling listener always checks the resync-request endpoint and triggers a resync when the request watermark is newer.

OCEAN_KAFKA_INTEGRATION_RESYNC_REQUESTS_TOPIC_ENABLED is unchanged — Kafka still uses the dedicated resync-requests topic only when that flag is on.

Note: This PR will be merged only on the deployment day of the feature.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

